### PR TITLE
Change hybrid core packages

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -15,7 +15,7 @@
 	},
 	"dependencies": {
 		"@openrouter/ai-sdk-provider": "catalog:ai",
-		"@hybrd/core": "workspace:*",
+		"hybrid": "workspace:*",
 		"@hybrd/xmtp": "workspace:*",
 		"zod": "catalog:stack"
 	},

--- a/examples/basic/src/agent.ts
+++ b/examples/basic/src/agent.ts
@@ -1,5 +1,5 @@
-import { Agent, MessageListenerConfig, Reaction } from "@hybrd/core"
 import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+import { Agent, MessageListenerConfig, Reaction } from "hybrid"
 
 export const openrouter = createOpenRouter({
 	apiKey: process.env.OPENROUTER_API_KEY

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,7 +13,7 @@ A flexible framework for building AI agents with plugin-based HTTP server extens
 ## Quick Start
 
 ```typescript
-import { Agent, XMTPPlugin, PonderPlugin } from "@hybrd/hybrid"
+import { Agent, XMTPPlugin, PonderPlugin } from "hybrid"
 
 // Create an agent
 const agent = new Agent({
@@ -48,7 +48,7 @@ The framework uses a plugin-based architecture that allows you to extend the age
 ### Creating Custom Plugins
 
 ```typescript
-import type { Plugin } from "@hybrd/hybrid"
+import type { Plugin } from "hybrid"
 import { Hono } from "hono"
 
 function MyCustomPlugin(): Plugin {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@hybrid/cli",
+	"name": "@hybrd/cli",
 	"version": "1.1.1",
 	"type": "module",
 	"bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,15 +1,12 @@
 {
-	"name": "hybrid",
+	"name": "@hybrid/cli",
 	"version": "1.1.1",
 	"type": "module",
 	"bin": {
 		"hybrid": "./dist/cli.js",
 		"hy": "./dist/cli.js"
 	},
-	"files": [
-		"dist",
-		"src"
-	],
+	"files": ["dist", "src"],
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,10 +27,10 @@
 		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
-		"@hybrd/utils": "workspace:*",
 		"@hybrd/xmtp": "workspace:*",
 		"degit": "^2.8.4",
 		"dotenv": "^16.4.5",
+		"tsx": "^4.20.5",
 		"uint8arrays": "^5.1.0",
 		"viem": "^2.33.3"
 	},

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,7 +13,7 @@ A flexible framework for building AI agents with plugin-based HTTP server extens
 ## Quick Start
 
 ```typescript
-import { Agent, XMTPPlugin, PonderPlugin } from "@hybrd/hybrid"
+import { Agent, XMTPPlugin, PonderPlugin } from "hybrid"
 
 // Create an agent
 const agent = new Agent({
@@ -48,7 +48,7 @@ The framework uses a plugin-based architecture that allows you to extend the age
 ### Creating Custom Plugins
 
 ```typescript
-import type { Plugin } from "@hybrd/hybrid"
+import type { Plugin } from "hybrid"
 import { Hono } from "hono"
 
 function MyCustomPlugin(): Plugin {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,11 +1,8 @@
 {
-	"name": "@hybrd/core",
+	"name": "hybrid",
 	"version": "1.1.1",
 	"type": "module",
-	"files": [
-		"dist",
-		"src"
-	],
+	"files": ["dist", "src"],
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,15 +40,15 @@ importers:
 
   examples/basic:
     dependencies:
-      '@hybrd/core':
-        specifier: workspace:*
-        version: link:../../packages/core
       '@hybrd/xmtp':
         specifier: workspace:*
         version: link:../../packages/xmtp
       '@openrouter/ai-sdk-provider':
         specifier: catalog:ai
         version: 1.1.2(ai@5.0.28(zod@4.0.17))(zod@4.0.17)
+      hybrid:
+        specifier: workspace:*
+        version: link:../../packages/core
       zod:
         specifier: catalog:stack
         version: 4.0.17
@@ -62,9 +62,6 @@ importers:
       '@types/node':
         specifier: catalog:stack
         version: 22.8.6
-      hybrid:
-        specifier: workspace:*
-        version: link:../../packages/cli
 
   packages/cli:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
 
   packages/cli:
     dependencies:
-      '@hybrd/utils':
-        specifier: workspace:*
-        version: link:../utils
       '@hybrd/xmtp':
         specifier: workspace:*
         version: link:../xmtp
@@ -77,6 +74,9 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
       uint8arrays:
         specifier: ^5.1.0
         version: 5.1.0
@@ -101,13 +101,13 @@ importers:
         version: 22.8.6
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.19.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.20.5))
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.19.3)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.19.3)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.20.5)
 
   packages/core:
     dependencies:
@@ -208,7 +208,7 @@ importers:
         version: 22.8.6
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.19.3)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)
 
   packages/xmtp:
     dependencies:
@@ -257,10 +257,10 @@ importers:
         version: 22.8.6
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(postcss@8.5.6)(tsx@4.19.3)(typescript@5.9.2)
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.19.3)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.20.5)
 
 packages:
 
@@ -2914,6 +2914,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo-darwin-64@2.5.0:
     resolution: {integrity: sha512-fP1hhI9zY8hv0idym3hAaXdPi80TLovmGmgZFocVAykFtOxF+GlfIgM/l4iLAV9ObIO4SUXPVWHeBZQQ+Hpjag==}
     cpu: [x64]
@@ -4687,7 +4692,7 @@ snapshots:
     dependencies:
       '@types/node': 22.17.2
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.19.3))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.20.5))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -4702,7 +4707,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.19.3)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.20.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -4721,6 +4726,14 @@ snapshots:
       magic-string: 0.30.18
     optionalDependencies:
       vite: 7.1.3(@types/node@22.8.6)(tsx@4.19.3)
+
+  '@vitest/mocker@3.2.4(vite@7.1.3(@types/node@22.8.6)(tsx@4.20.5))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.18
+    optionalDependencies:
+      vite: 7.1.3(@types/node@22.8.6)(tsx@4.20.5)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6742,6 +6755,13 @@ snapshots:
       postcss: 8.5.6
       tsx: 4.19.3
 
+  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.20.5):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+      tsx: 4.20.5
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -7159,7 +7179,42 @@ snapshots:
       - tsx
       - yaml
 
+  tsup@8.5.0(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.9)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.1
+      esbuild: 0.25.9
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.20.5)
+      resolve-from: 5.0.0
+      rollup: 4.48.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   tsx@4.19.3:
+    dependencies:
+      esbuild: 0.25.9
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tsx@4.20.5:
     dependencies:
       esbuild: 0.25.9
       get-tsconfig: 4.10.1
@@ -7398,6 +7453,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@22.8.6)(tsx@4.20.5):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.3(@types/node@22.8.6)(tsx@4.20.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.1.3(@types/node@22.8.6)(tsx@4.19.3):
     dependencies:
       esbuild: 0.25.9
@@ -7410,6 +7486,19 @@ snapshots:
       '@types/node': 22.8.6
       fsevents: 2.3.3
       tsx: 4.19.3
+
+  vite@7.1.3(@types/node@22.8.6)(tsx@4.20.5):
+    dependencies:
+      esbuild: 0.25.9
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.48.0
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 22.8.6
+      fsevents: 2.3.3
+      tsx: 4.20.5
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.19.3):
     dependencies:
@@ -7435,6 +7524,48 @@ snapshots:
       tinyrainbow: 2.0.0
       vite: 7.1.3(@types/node@22.8.6)(tsx@4.19.3)
       vite-node: 3.2.4(@types/node@22.8.6)(tsx@4.19.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.8.6
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.8.6)(tsx@4.20.5):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.1.3(@types/node@22.8.6)(tsx@4.20.5))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.18
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.1.3(@types/node@22.8.6)(tsx@4.20.5)
+      vite-node: 3.2.4(@types/node@22.8.6)(tsx@4.20.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/templates/agent/package.json
+++ b/templates/agent/package.json
@@ -20,12 +20,13 @@
 		"clean": "rimraf dist node_modules"
 	},
 	"dependencies": {
-		"@openrouter/ai-sdk-provider": "^1.1.2"
+		"@openrouter/ai-sdk-provider": "^1.1.2",
+		"hybrid": "latest"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
 		"@types/node": "^22.0.0",
-		"hybrid": "^1.0.1",
+		"@hybrid/cli": "latest",
 		"typescript": "^5.8.3",
 		"vitest": "^3.2.4"
 	},

--- a/templates/agent/package.json
+++ b/templates/agent/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "{{projectName}}",
-	"version": "0.1.0",
+	"version": "0.0.0",
 	"private": true,
 	"description": "A Hybrid XMTP agent project",
 	"type": "module",


### PR DESCRIPTION
This is a cleaner DX to import { Agent } from "hybrid"
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Rename core package to “hybrid” and move the CLI to “@hybrd/cli” to simplify imports. Users can now import { Agent } from "hybrid"; examples, templates, and docs are updated.

- **Migration**
  - Replace imports from "@hybrd/core" or "@hybrd/hybrid" with "hybrid".
  - Update package.json: replace "@hybrd/core"/"@hybrd/hybrid" with "hybrid".
  - If you depended on the CLI as "hybrid", switch to "@hybrd/cli". The "hybrid" and "hy" commands remain.

- **Dependencies**
  - CLI: add "tsx"; remove unused "@hybrd/utils".
  - Update templates to use the new package names.

<!-- End of auto-generated description by cubic. -->

