### PR TITLE
tests

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -72,10 +72,6 @@ jobs:
             echo "❌ Project creation failed"
             exit 1
           fi
-          
-          # INTENTIONAL FAILURE FOR TESTING CI - REMOVE THIS LINE
-          echo "❌ Intentional test failure to verify CI error handling"
-          exit 1
           echo "✅ Project created successfully"
         working-directory: test-project
 

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,18 +1,7 @@
 name: Test Hybrid CLI
 
 on:
-  push:
-    branches: [main, develop]
-    paths:
-      - 'packages/cli/**'
-      - 'packages/create-hybrid/**'
-      - '.github/workflows/test-cli.yml'
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'packages/cli/**'
-      - 'packages/create-hybrid/**'
-      - '.github/workflows/test-cli.yml'
+  pull_request
 
 jobs:
   test-cli:

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -2,7 +2,6 @@ name: Test Hybrid CLI
 
 on:
   push:
-    branches: main
   pull_request:
     branches: main
 

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -537,8 +537,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build CLI
-        run: pnpm build --filter=hybrid
+      - name: Build all packages
+        run: pnpm build
 
       - name: Run CLI integration tests with Vitest
         run: |

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -5,11 +5,13 @@ on:
     branches: [main, develop]
     paths:
       - 'packages/cli/**'
+      - 'packages/create-hybrid/**'
       - '.github/workflows/test-cli.yml'
   pull_request:
     branches: [main, develop]
     paths:
       - 'packages/cli/**'
+      - 'packages/create-hybrid/**'
       - '.github/workflows/test-cli.yml'
 
 jobs:
@@ -33,7 +35,7 @@ jobs:
       - name: Build all packages
         run: pnpm build
 
-      - name: Verify CLI binary exists
+      - name: Verify CLI and create-hybrid binaries exist
         run: |
           echo "🔍 Checking CLI binary..."
           if [ ! -f "packages/cli/dist/cli.js" ]; then
@@ -43,6 +45,15 @@ jobs:
           fi
           echo "✅ CLI binary exists"
           ls -la packages/cli/dist/cli.js
+
+          echo "🔍 Checking create-hybrid binary..."
+          if [ ! -f "packages/create-hybrid/dist/index.js" ]; then
+            echo "❌ create-hybrid binary not found at packages/create-hybrid/dist/index.js"
+            ls -la packages/create-hybrid/dist/
+            exit 1
+          fi
+          echo "✅ create-hybrid binary exists"
+          ls -la packages/create-hybrid/dist/index.js
 
           echo "🔍 Testing CLI help command..."
           if ! node packages/cli/dist/cli.js --help; then
@@ -69,7 +80,7 @@ jobs:
       - name: Test project creation with specific name
         run: |
           echo "🔍 Testing project creation with name 'test-agent-cli'..."
-          if ! node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" init test-agent-cli; then
+          if ! node "$GITHUB_WORKSPACE/packages/create-hybrid/dist/index.js" test-agent-cli; then
             echo "❌ Project creation failed"
             exit 1
           fi
@@ -256,8 +267,8 @@ jobs:
       - name: Test interactive project creation
         run: |
           echo "🔍 Testing interactive project creation..."
-          echo "📝 Providing empty input to trigger interactive mode..."
-          if ! echo -e "\n" | node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" init; then
+          echo "📝 Providing project name via stdin..."
+          if ! echo "my-hybrid-agent" | node "$GITHUB_WORKSPACE/packages/create-hybrid/dist/index.js"; then
             echo "❌ Interactive project creation failed"
             exit 1
           fi
@@ -342,7 +353,7 @@ jobs:
           cd edge-case-test
 
           echo "📁 Creating project in current directory..."
-          if ! node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" init .; then
+          if ! node "$GITHUB_WORKSPACE/packages/create-hybrid/dist/index.js" .; then
             echo "❌ Failed to create project in current directory"
             cd ..
             rm -rf edge-case-test
@@ -362,7 +373,7 @@ jobs:
 
           echo "🧪 Test 2: Project name with special characters"
           echo "📝 Testing project creation with special characters..."
-          if ! node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" init "My Amazing Agent!"; then
+          if ! node "$GITHUB_WORKSPACE/packages/create-hybrid/dist/index.js" "My Amazing Agent!"; then
             echo "❌ Failed to create project with special characters"
             exit 1
           fi
@@ -415,21 +426,21 @@ jobs:
           mkdir -p /tmp/cli-test
           cd /tmp/cli-test
 
-      - name: Test CLI as npx command
+      - name: Test create-hybrid command
         run: |
-          echo "🔍 Testing CLI as npx command simulation..."
+          echo "🔍 Testing create-hybrid command simulation..."
           cd /tmp/cli-test
 
           echo "📦 Setting up NODE_PATH for dependency resolution..."
           export NODE_PATH="/home/runner/work/hybrid/hybrid/packages/cli/node_modules:$NODE_PATH"
           echo "✅ NODE_PATH configured"
 
-          echo "🚀 Running CLI init command for demo-project..."
-          if ! node "$GITHUB_WORKSPACE/packages/cli/dist/cli.js" init demo-project; then
-            echo "❌ CLI init command failed"
+          echo "🚀 Running create-hybrid command for demo-project..."
+          if ! node "$GITHUB_WORKSPACE/packages/create-hybrid/dist/index.js" demo-project; then
+            echo "❌ create-hybrid command failed"
             exit 1
           fi
-          echo "✅ CLI init command completed"
+          echo "✅ create-hybrid command completed"
 
           echo "🔍 Verifying project creation..."
           if [ ! -d "demo-project" ]; then

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -3,10 +3,6 @@ name: Test Hybrid CLI
 on:
   push:
     branches: [main, develop]
-    paths:
-      - 'packages/cli/**'
-      - 'packages/create-hybrid/**'
-      - '.github/workflows/test-cli.yml'
   pull_request:
     branches: main
 

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,9 +1,6 @@
 name: Test Hybrid CLI
 
-on:
-  push:
-  pull_request:
-    branches: main
+on: [push, pull_request]
 
 jobs:
   test-cli:

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,7 +1,8 @@
 name: Test Hybrid CLI
 
 on:
-  pull_request
+  pull_request:
+    branches: main
 
 jobs:
   test-cli:

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,6 +1,12 @@
 name: Test Hybrid CLI
 
 on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'packages/cli/**'
+      - 'packages/create-hybrid/**'
+      - '.github/workflows/test-cli.yml'
   pull_request:
     branches: main
 

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,6 +1,6 @@
 name: Test Hybrid CLI
 
-on: [push, pull_request]
+on: push
 
 jobs:
   test-cli:
@@ -157,13 +157,13 @@ jobs:
           echo "✅ Name field is correct: test-agent-cli"
 
           # Check version field
-          if ! grep -q '"version": "0.1.0"' package.json; then
+          if ! grep -q '"version": "0.0.0"' package.json; then
             echo "❌ Expected version field not found"
             echo "Current version field:"
             node -e "console.log(JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version)"
             exit 1
           fi
-          echo "✅ Version field is correct: 0.1.0"
+          echo "✅ Version field is correct: 0.0.0"
 
           # Check dev script (from template: "hybrid dev")
           if ! grep -q '"dev": "hybrid dev"' package.json; then
@@ -175,7 +175,7 @@ jobs:
           echo "✅ Dev script is correct"
 
           # Check keys script
-          if ! grep -q '"keys": "hybrid gen:keys"' package.json; then
+          if ! grep -q '"keys": "hybrid gen:keys --write"' package.json; then
             echo "❌ Expected keys script not found"
             echo "Current scripts:"
             node -e "console.log(JSON.stringify(JSON.parse(require('fs').readFileSync('package.json', 'utf8')).scripts, null, 2))"

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -2,7 +2,7 @@ name: Test Hybrid CLI
 
 on:
   push:
-    branches: [main, develop]
+    branches: main
   pull_request:
     branches: main
 

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -84,6 +84,10 @@ jobs:
             echo "❌ Project creation failed"
             exit 1
           fi
+          
+          # INTENTIONAL FAILURE FOR TESTING CI - REMOVE THIS LINE
+          echo "❌ Intentional test failure to verify CI error handling"
+          exit 1
           echo "✅ Project created successfully"
         working-directory: test-project
 

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -91,7 +91,6 @@ jobs:
           fi
           echo "✅ Project directory exists"
           ls -la test-agent-cli/
-        working-directory: test-project
 
           echo "📂 Checking src directory..."
           if [ ! -d "test-agent-cli/src" ]; then

--- a/packages/cli/tests/cli.integration.test.ts
+++ b/packages/cli/tests/cli.integration.test.ts
@@ -11,9 +11,6 @@ function runCliCommand(
 	try {
 		const { execSync } = require("node:child_process")
 		const cliPath = join(process.cwd(), "dist/cli.js")
-		console.log(`Running CLI command: node "${cliPath}" ${args.map(arg => `"${arg}"`).join(" ")}`)
-		console.log(`Working directory: ${cwd || process.cwd()}`)
-		console.log(`CLI binary exists: ${require("node:fs").existsSync(cliPath)}`)
 		
 		const result = execSync(
 			`node "${cliPath}" ${args.map(arg => `"${arg}"`).join(" ")}`,
@@ -26,9 +23,6 @@ function runCliCommand(
 		)
 		return { stdout: result, stderr: "", exitCode: 0 }
 	} catch (error: any) {
-		console.log(`CLI command failed with exit code: ${error.status}`)
-		console.log(`Stdout: ${error.stdout || ""}`)
-		console.log(`Stderr: ${error.stderr || ""}`)
 		return {
 			stdout: error.stdout || "",
 			stderr: error.stderr || "",
@@ -50,9 +44,6 @@ function runCreateHybridCommand(
 			: currentDir
 		const createHybridPath = join(monorepoRoot, "packages", "create-hybrid", "dist", "index.js")
 		
-		console.log(`Running create-hybrid command: node "${createHybridPath}" "${projectName}"`)
-		console.log(`Working directory: ${cwd || process.cwd()}`)
-		console.log(`create-hybrid binary exists: ${require("node:fs").existsSync(createHybridPath)}`)
 		
 		const result = execSync(
 			`node "${createHybridPath}" "${projectName}"`,
@@ -65,9 +56,6 @@ function runCreateHybridCommand(
 		)
 		return { stdout: result, stderr: "", exitCode: 0 }
 	} catch (error: any) {
-		console.log(`create-hybrid command failed with exit code: ${error.status}`)
-		console.log(`Stdout: ${error.stdout || ""}`)
-		console.log(`Stderr: ${error.stderr || ""}`)
 		return {
 			stdout: error.stdout || "",
 			stderr: error.stderr || "",

--- a/packages/cli/tests/cli.integration.test.ts
+++ b/packages/cli/tests/cli.integration.test.ts
@@ -10,8 +10,13 @@ function runCliCommand(
 ): { stdout: string; stderr: string; exitCode: number } {
 	try {
 		const { execSync } = require("node:child_process")
+		const cliPath = join(process.cwd(), "dist/cli.js")
+		console.log(`Running CLI command: node "${cliPath}" ${args.map(arg => `"${arg}"`).join(" ")}`)
+		console.log(`Working directory: ${cwd || process.cwd()}`)
+		console.log(`CLI binary exists: ${require("node:fs").existsSync(cliPath)}`)
+		
 		const result = execSync(
-			`node "${join(process.cwd(), "dist/cli.js")}" ${args.map(arg => `"${arg}"`).join(" ")}`,
+			`node "${cliPath}" ${args.map(arg => `"${arg}"`).join(" ")}`,
 			{
 				cwd: cwd || process.cwd(),
 				encoding: "utf8",
@@ -21,6 +26,9 @@ function runCliCommand(
 		)
 		return { stdout: result, stderr: "", exitCode: 0 }
 	} catch (error: any) {
+		console.log(`CLI command failed with exit code: ${error.status}`)
+		console.log(`Stdout: ${error.stdout || ""}`)
+		console.log(`Stderr: ${error.stderr || ""}`)
 		return {
 			stdout: error.stdout || "",
 			stderr: error.stderr || "",
@@ -42,6 +50,10 @@ function runCreateHybridCommand(
 			: currentDir
 		const createHybridPath = join(monorepoRoot, "packages", "create-hybrid", "dist", "index.js")
 		
+		console.log(`Running create-hybrid command: node "${createHybridPath}" "${projectName}"`)
+		console.log(`Working directory: ${cwd || process.cwd()}`)
+		console.log(`create-hybrid binary exists: ${require("node:fs").existsSync(createHybridPath)}`)
+		
 		const result = execSync(
 			`node "${createHybridPath}" "${projectName}"`,
 			{
@@ -53,6 +65,9 @@ function runCreateHybridCommand(
 		)
 		return { stdout: result, stderr: "", exitCode: 0 }
 	} catch (error: any) {
+		console.log(`create-hybrid command failed with exit code: ${error.status}`)
+		console.log(`Stdout: ${error.stdout || ""}`)
+		console.log(`Stderr: ${error.stderr || ""}`)
 		return {
 			stdout: error.stdout || "",
 			stderr: error.stderr || "",

--- a/packages/cli/tests/cli.integration.test.ts
+++ b/packages/cli/tests/cli.integration.test.ts
@@ -35,7 +35,13 @@ function runCreateHybridCommand(
 ): { stdout: string; stderr: string; exitCode: number } {
 	try {
 		const { execSync } = require("node:child_process")
-		const createHybridPath = join(process.cwd(), "..", "create-hybrid", "dist", "index.js")
+		// Try to find the create-hybrid binary relative to the monorepo root
+		const currentDir = process.cwd()
+		const monorepoRoot = currentDir.includes('/packages/cli') 
+			? join(currentDir, '..', '..')
+			: currentDir
+		const createHybridPath = join(monorepoRoot, "packages", "create-hybrid", "dist", "index.js")
+		
 		const result = execSync(
 			`node "${createHybridPath}" "${projectName}"`,
 			{

--- a/packages/cli/tests/cli.integration.test.ts
+++ b/packages/cli/tests/cli.integration.test.ts
@@ -131,7 +131,7 @@ describe("CLI Integration Tests", () => {
 				readFileSync(join(projectPath, "package.json"), "utf8")
 			)
 			expect(packageJson.name).toBe(projectName)
-			expect(packageJson.version).toBe("0.1.0")
+			expect(packageJson.version).toBe("0.0.0")
 
 			cleanupTempProject(projectName)
 		})

--- a/packages/cli/tests/cli.integration.test.ts
+++ b/packages/cli/tests/cli.integration.test.ts
@@ -11,9 +11,9 @@ function runCliCommand(
 	try {
 		const { execSync } = require("node:child_process")
 		const cliPath = join(process.cwd(), "dist/cli.js")
-		
+
 		const result = execSync(
-			`node "${cliPath}" ${args.map(arg => `"${arg}"`).join(" ")}`,
+			`node "${cliPath}" ${args.map((arg) => `"${arg}"`).join(" ")}`,
 			{
 				cwd: cwd || process.cwd(),
 				encoding: "utf8",
@@ -39,21 +39,23 @@ function runCreateHybridCommand(
 		const { execSync } = require("node:child_process")
 		// Try to find the create-hybrid binary relative to the monorepo root
 		const currentDir = process.cwd()
-		const monorepoRoot = currentDir.includes('/packages/cli') 
-			? join(currentDir, '..', '..')
+		const monorepoRoot = currentDir.includes("/packages/cli")
+			? join(currentDir, "..", "..")
 			: currentDir
-		const createHybridPath = join(monorepoRoot, "packages", "create-hybrid", "dist", "index.js")
-		
-		
-		const result = execSync(
-			`node "${createHybridPath}" "${projectName}"`,
-			{
-				cwd: cwd || process.cwd(),
-				encoding: "utf8",
-				stdio: "pipe",
-				timeout: 30000
-			}
+		const createHybridPath = join(
+			monorepoRoot,
+			"packages",
+			"create-hybrid",
+			"dist",
+			"index.js"
 		)
+
+		const result = execSync(`node "${createHybridPath}" "${projectName}"`, {
+			cwd: cwd || process.cwd(),
+			encoding: "utf8",
+			stdio: "pipe",
+			timeout: 30000
+		})
 		return { stdout: result, stderr: "", exitCode: 0 }
 	} catch (error: any) {
 		return {
@@ -121,10 +123,7 @@ describe("CLI Integration Tests", () => {
 			const projectName = "test-project-cli"
 			const tempDir = join(process.cwd(), "test-temp")
 
-			const result = runCreateHybridCommand(
-				projectName,
-				tempDir
-			)
+			const result = runCreateHybridCommand(projectName, tempDir)
 			expect(result.exitCode).toBe(0)
 			expect(result.stdout).toContain("Hybrid project created successfully")
 
@@ -145,20 +144,19 @@ describe("CLI Integration Tests", () => {
 			cleanupTempProject(projectName)
 		})
 
-	it("should create a project in current directory when name is '.'", () => {
-		const projectName = "test-current-dir"
-		const tempDir = createTempProject(projectName)
+		it("should create a project in current directory when name is '.'", () => {
+			const projectName = "test-current-dir"
+			const tempDir = createTempProject(projectName)
 
-		// Ensure directory is empty for the test
-		const { execSync } = require("node:child_process")
-		try {
-			execSync(`find ${tempDir} -mindepth 1 -delete`, { stdio: "ignore" })
-		} catch (e) {
-		}
+			// Ensure directory is empty for the test
+			const { execSync } = require("node:child_process")
+			try {
+				execSync(`find ${tempDir} -mindepth 1 -delete`, { stdio: "ignore" })
+			} catch (e) {}
 
-		const result = runCreateHybridCommand(".", tempDir)
-		expect(result.exitCode).toBe(0)
-		expect(result.stdout).toContain("Hybrid project created successfully")
+			const result = runCreateHybridCommand(".", tempDir)
+			expect(result.exitCode).toBe(0)
+			expect(result.stdout).toContain("Hybrid project created successfully")
 
 			// Verify files are created in current directory
 			expect(existsSync(join(tempDir, "package.json"))).toBe(true)
@@ -188,17 +186,19 @@ describe("CLI Integration Tests", () => {
 			cleanupTempProject(expectedName)
 		})
 
-	it("should fail when trying to create project in non-empty directory", () => {
-		const projectName = "test-existing-dir"
-		const tempDir = join(process.cwd(), "test-temp")
+		it("should fail when trying to create project in non-empty directory", () => {
+			const projectName = "test-existing-dir"
+			const tempDir = join(process.cwd(), "test-temp")
 
-		// Create the project directory and add a file to it
-		execSync(`mkdir -p ${join(tempDir, projectName)}`)
-		execSync(`echo "existing file" > ${join(tempDir, projectName, "existing.txt")}`)
+			// Create the project directory and add a file to it
+			execSync(`mkdir -p ${join(tempDir, projectName)}`)
+			execSync(
+				`echo "existing file" > ${join(tempDir, projectName, "existing.txt")}`
+			)
 
-		const result = runCreateHybridCommand(projectName, tempDir)
-		expect(result.exitCode).toBe(1)
-		expect(result.stderr).toContain("already exists and is not empty")
+			const result = runCreateHybridCommand(projectName, tempDir)
+			expect(result.exitCode).toBe(1)
+			expect(result.stderr).toContain("already exists and is not empty")
 
 			cleanupTempProject(projectName)
 		})
@@ -212,10 +212,10 @@ describe("CLI Integration Tests", () => {
 			// First create a project
 			runCreateHybridCommand(projectName, tempDir)
 
-		// Change to project directory and generate keys
-		const projectPath = join(tempDir, projectName)
-		const result = runCliCommand(["gen:keys", "--write"], projectPath)
-		expect(result.exitCode).toBe(0)
+			// Change to project directory and generate keys
+			const projectPath = join(tempDir, projectName)
+			const result = runCliCommand(["gen:keys", "--write"], projectPath)
+			expect(result.exitCode).toBe(0)
 			expect(result.stdout).toContain("Keys generated successfully")
 
 			// Verify .env file contains keys
@@ -275,12 +275,12 @@ describe("CLI Integration Tests", () => {
 			// Create a project
 			runCreateHybridCommand(projectName, tempDir)
 
-		// Start dev server with timeout
-		const projectPath = join(tempDir, projectName)
-		const child = spawn("node", [join(process.cwd(), "dist/cli.js"), "dev"], {
-			cwd: projectPath,
-			stdio: "pipe"
-		})
+			// Start dev server with timeout
+			const projectPath = join(tempDir, projectName)
+			const child = spawn("node", [join(process.cwd(), "dist/cli.js"), "dev"], {
+				cwd: projectPath,
+				stdio: "pipe"
+			})
 
 			let output = ""
 			child.stdout?.on("data", (data) => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update the CLI CI workflow to test the new create-hybrid binary and fix project creation tests. This covers both binaries and verifies init flows in non-interactive and interactive modes.

- **Bug Fixes**
  - Trigger workflow on changes to packages/create-hybrid.
  - Verify CLI and create-hybrid binaries exist before tests.
  - Use create-hybrid for all project creation tests (args and stdin).
  - Replace the npx simulation step to call create-hybrid and check output.

<!-- End of auto-generated description by cubic. -->

