### PR TITLE
Modify clean command to preserve node_modules

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -94,7 +94,7 @@ async function main() {
 			console.log("Commands:")
 			console.log("  dev          Start development server with watch mode")
 			console.log("  build        Build the TypeScript project")
-			console.log("  clean        Remove dist and node_modules directories")
+			console.log("  clean        Remove dist directory")
 			console.log(
 				"  upgrade|up   Upgrade all hybrid and @hybrd/* packages to latest"
 			)

--- a/packages/cli/src/cmd/clean.ts
+++ b/packages/cli/src/cmd/clean.ts
@@ -2,13 +2,12 @@ import { existsSync } from "node:fs"
 import { join } from "node:path"
 import { rimraf } from "rimraf"
 
-// Clean the project (remove dist and node_modules)
+// Clean the project (remove dist directory)
 export async function runClean() {
 	console.log("🧹 Cleaning project...")
 
 	const cwd = process.cwd()
 	const distPath = join(cwd, "dist")
-	const nodeModulesPath = join(cwd, "node_modules")
 
 	try {
 		// Remove dist directory
@@ -18,15 +17,6 @@ export async function runClean() {
 			console.log("✅ Removed dist directory")
 		} else {
 			console.log("⚠️  dist directory not found, skipping...")
-		}
-
-		// Remove node_modules directory
-		if (existsSync(nodeModulesPath)) {
-			console.log("Removing node_modules directory...")
-			await rimraf(nodeModulesPath)
-			console.log("✅ Removed node_modules directory")
-		} else {
-			console.log("⚠️  node_modules directory not found, skipping...")
 		}
 
 		console.log("🎉 Project cleaned successfully!")


### PR DESCRIPTION
# Modify clean command to preserve node_modules

## Summary
Modified the `hybrid clean` command to only remove the `dist` directory while preserving `node_modules`. This change improves developer experience by avoiding slow dependency reinstallation during routine cleanup operations.

**Changes made:**
- Removed node_modules cleanup logic from `runClean()` function in `packages/cli/src/cmd/clean.ts`
- Updated CLI help text from "Remove dist and node_modules directories" to "Remove dist directory"
- Updated function comment to reflect new behavior

This addresses Linear ticket **HYBRID-22**.

## Review & Testing Checklist for Human
- [ ] Test the `hybrid clean` command actually works and only removes `dist` directory
- [ ] Verify `node_modules` directory is preserved after running clean
- [ ] Check if any existing documentation or workflows reference the old behavior and need updating

### Notes
- This is a **breaking behavioral change** that removes functionality existing users might depend on
- Consider whether a deprecation warning or optional flag (e.g., `--node-modules`) should be added in a future iteration
- No automated tests were added/modified as part of this change

**Link to Devin run:** https://app.devin.ai/sessions/18c87f1aff8e4dc8acf1ad173f36e2a2  
**Requested by:** @ian
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update hybrid clean to only remove the dist directory and preserve node_modules. This speeds up routine cleanups and updates the CLI help text accordingly, aligning with HYBRID-22.

<!-- End of auto-generated description by cubic. -->

