### PR TITLE
Don't export toolFactory

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ export { Agent } from "./core/agent"
 export type { AgentConfig, DefaultRuntimeExtension } from "./core/agent"
 export { PluginRegistry } from "./core/plugin"
 export type { Plugin } from "./core/plugin"
-export { createTool, toolFactory } from "./core/tool"
+export { createTool } from "./core/tool"
 export { listen } from "./server/listen"
 export type { ListenOptions } from "./server/listen"
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed toolFactory from the core public exports to simplify the tool API and guide usage toward createTool. Projects importing toolFactory may need small updates.

- **Migration**
  - Replace `import { toolFactory } from "@core"` with `import { createTool } from "@core"`.
  - Update usage to call `createTool(...)` accordingly.

<sup>Written for commit ce9b0013842d9c44a0ba0a173b7ac7b0fe770874. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

