### PR TITLE
feat: Spawn + Sprites deployment target (HYBRID-140)

### DIFF
--- a/deployments/spawn/Dockerfile
+++ b/deployments/spawn/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:20-bookworm-slim
+
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY package.json ./
+RUN npm install --production
+
+# Copy built agent runtime
+COPY server/ ./server/
+
+# Copy config files
+COPY SOUL.md ./
+COPY AGENTS.md ./
+COPY IDENTITY.md ./
+COPY TOOLS.md ./
+COPY BOOT.md ./
+COPY BOOTSTRAP.md ./
+COPY HEARTBEAT.md ./
+COPY USER.md ./
+
+# Copy credentials (owner ACL)
+COPY credentials/ ./credentials/ 2>/dev/null || true
+
+# Create data directories
+RUN mkdir -p /app/data/secrets \
+    /app/data/memory/users \
+    /app/data/memory/life/projects \
+    /app/data/memory/life/areas \
+    /app/data/memory/life/resources \
+    /app/data/memory/life/archives \
+    /app/data/memory/logs \
+    /app/data/workspaces && \
+    chown -R node:node /app/data
+
+ENV AGENT_PORT=8454
+ENV NODE_ENV=production
+ENV DATA_ROOT=/app/data
+
+EXPOSE 8454
+
+USER node
+CMD ["node", "server/index.cjs"]

--- a/deployments/spawn/Dockerfile
+++ b/deployments/spawn/Dockerfile
@@ -20,7 +20,7 @@ COPY HEARTBEAT.md ./
 COPY USER.md ./
 
 # Copy credentials (owner ACL)
-COPY credentials/ ./credentials/ 2>/dev/null || true
+COPY credentials/ ./credentials/
 
 # Create data directories
 RUN mkdir -p /app/data/secrets \

--- a/hybrid.config.ts
+++ b/hybrid.config.ts
@@ -1,3 +1,3 @@
-const deployPlatform = "firecracker"
+const deployPlatform = "sprites"
 
 export default {}

--- a/hybrid.config.ts
+++ b/hybrid.config.ts
@@ -1,0 +1,3 @@
+const deployPlatform = "firecracker"
+
+export default {}

--- a/ian/spawn/installers/hybrid.sh
+++ b/ian/spawn/installers/hybrid.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eo pipefail
+
+# Thin shim: ensures bun is available, runs bundled sprite.js (local or from GitHub release)
+
+_ensure_bun() {
+    if command -v bun &>/dev/null; then return 0; fi
+    printf '\033[0;36mInstalling bun...\033[0m\n' >&2
+    curl -fsSL --proto '=https' --show-error https://bun.sh/install?version=1.3.9 | bash >/dev/null || { printf '\033[0;31mFailed to install bun\033[0m\n' >&2; exit 1; }
+    export PATH="$HOME/.bun/bin:$PATH"
+    command -v bun &>/dev/null || { printf '\033[0;31mbun not found after install\033[0m\n' >&2; exit 1; }
+}
+
+_ensure_bun
+
+# SPAWN_CLI_DIR override — force local source (used by e2e tests)
+if [[ -n "${SPAWN_CLI_DIR:-}" && -f "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" ]]; then
+    exec bun run "$SPAWN_CLI_DIR/packages/cli/src/sprite/main.ts" hybrid "$@"
+fi
+
+# Remote — download bundled sprite.js from GitHub release
+SPRITE_JS=$(mktemp)
+trap 'rm -f "$SPRITE_JS"' EXIT
+curl -fsSL --proto '=https' "https://github.com/OpenRouterTeam/spawn/releases/download/sprite-latest/sprite.js" -o "$SPRITE_JS" \
+    || { printf '\033[0;31mFailed to download sprite.js\033[0m\n' >&2; exit 1; }
+
+exec bun run "$SPRITE_JS" hybrid "$@"

--- a/ian/spawn/manifest.json
+++ b/ian/spawn/manifest.json
@@ -1,0 +1,49 @@
+{
+  "agents": {
+    "hybrid": {
+      "name": "Hybrid",
+      "description": "Self-hosted AI agent platform with encrypted sessions and wallet-based access control",
+      "url": "https://github.com/anomalyco/hybrid",
+      "install": "cd /app && npm install --production",
+      "launch": "cd /app && node server/index.cjs",
+      "env": {
+        "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}",
+        "NODE_ENV": "production",
+        "AGENT_PORT": "8454"
+      },
+      "config_files": {},
+      "notes": "Hybrid uses a single-sprite deployment model. Build with `hybrid build --target spawn` first, then deploy.",
+      "icon": "https://raw.githubusercontent.com/anomalyco/hybrid/main/site/public/icon.png",
+      "featured_cloud": ["sprite"],
+      "creator": "01 Studio",
+      "repo": "anomalyco/hybrid",
+      "license": "MIT",
+      "created": "2026-04",
+      "added": "2026-04",
+      "github_stars": 0,
+      "stars_updated": "2026-04",
+      "language": "TypeScript",
+      "runtime": "node",
+      "category": "cli",
+      "tagline": "Your personal AI agent, self-hosted",
+      "tags": ["ai-agent", "self-hosted", "claude-code", "encrypted"]
+    }
+  },
+  "clouds": {
+    "sprite": {
+      "name": "Sprite",
+      "price": "Free tier",
+      "description": "Managed cloud servers -- one command to deploy",
+      "url": "https://sprites.dev",
+      "type": "cli",
+      "auth": "sprite login",
+      "provision_method": "sprite create",
+      "exec_method": "sprite exec",
+      "interactive_method": "sprite exec -tty",
+      "icon": "https://raw.githubusercontent.com/OpenRouterTeam/spawn/main/assets/clouds/sprite.png"
+    }
+  },
+  "matrix": {
+    "sprite/hybrid": "implemented"
+  }
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,18 +47,19 @@ my-agent/
 
 ### `hybrid build [--target]`
 
-Build the agent bundle into `.hybrid/`:
+Build the agent bundle into `./dist/`:
 
 ```bash
 hybrid build                  # Default build
 hybrid build --target fly     # Fly.io target (default)
+hybrid build --target spawn   # Spawn Sprite target
 hybrid build --target railway # Railway target
 hybrid build --target cf      # Cloudflare Workers target
 ```
 
 The build:
 1. Compiles `packages/agent` via `pnpm --filter hybrid/agent build`
-2. Creates `.hybrid/` directory structure
+2. Creates `./dist/` directory structure
 3. Copies compiled `dist/` from the agent package
 4. Copies `SOUL.md`, `AGENTS.md`, and `agent.ts` from your project root
 5. Copies core skills from `packages/agent/skills/` → `.hybrid/skills/core/`
@@ -68,7 +69,7 @@ The build:
 
 **Build output structure:**
 ```
-.hybrid/
+dist/
 ├── dist/                    # Compiled agent code
 │   ├── server/index.cjs     # Full Claude Code SDK server
 │   ├── server/simple.cjs    # Lightweight server
@@ -79,6 +80,34 @@ The build:
 ├── package.json
 ├── Dockerfile
 ├── fly.toml                 # (Fly.io targets only)
+├── spawn.sh                 # (Spawn targets only)
+└── start.sh                 # Starts server
+```
+
+The build:
+1. Compiles `packages/agent` via `pnpm --filter hybrid/agent build`
+2. Creates `./dist/` directory structure
+3. Copies compiled `dist/` from the agent package
+4. Copies `SOUL.md`, `AGENTS.md`, and `agent.ts` from your project root
+5. Copies core skills from `packages/agent/skills/` → `.hybrid/skills/core/`
+6. Copies user skills from `./skills/` → `.hybrid/skills/ext/`
+7. Writes `skills/skills_lock.json` listing all installed skills
+8. Generates deployment files: `package.json`, `Dockerfile`, `fly.toml`, `start.sh`
+
+**Build output structure:**
+```
+dist/
+├── dist/                    # Compiled agent code
+│   ├── server/index.cjs     # Full Claude Code SDK server
+│   ├── server/simple.cjs    # Lightweight server
+├── skills/
+│   ├── core/                # Built-in skills (memory)
+│   ├── ext/                 # User-installed skills
+│   └── skills_lock.json
+├── package.json
+├── Dockerfile
+├── fly.toml                 # (Fly.io targets only)
+├── spawn.sh                 # (Spawn targets only)
 └── start.sh                 # Starts server
 ```
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,16 @@
 		"tsup": "^8.5.0",
 		"vitest": "^3.2.4"
 	},
+	"peerDependencies": {
+		"e2b": "^2.0.0"
+	},
+	"peerDependenciesMeta": {
+		"e2b": {
+			"optional": true
+		}
+	},
 	"optionalDependencies": {
+		"e2b": "^2.19.0",
 		"node-llama-cpp": "^3.0.0",
 		"sqlite-vec": "^0.1.0"
 	}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -715,9 +715,23 @@ async function loadDeploy() {
 }
 
 function parseDeployArgs(args: string[]) {
-	const name = args.find(
-		(a, i) => i > 1 && !a.startsWith("--") && !a.startsWith("-"),
-	)
+	// Collect known flag indices so we don't mistake flag values as positional names
+	const skipSet = new Set<number>()
+	const flagNames = [
+		"--provider",
+		"-p",
+		"--name",
+		"-n",
+		"--no-build",
+		"--force",
+		"--no-follow",
+	]
+	for (let i = 0; i < args.length; i++) {
+		if (flagNames.includes(args[i])) {
+			skipSet.add(i)
+			skipSet.add(i + 1)
+		}
+	}
 	const providerIdx = args.indexOf("--provider")
 	const providerAltIdx = args.indexOf("-p")
 	const nameIdx = args.indexOf("--name")
@@ -728,14 +742,29 @@ function parseDeployArgs(args: string[]) {
 	const nameFlag =
 		(nameIdx !== -1 ? args[nameIdx + 1] : undefined) ||
 		(nameAltIdx !== -1 ? args[nameAltIdx + 1] : undefined)
-	const posArg =
-		args[1] && !args[1].startsWith("-") ? args[1] : undefined
+
+	// Find the first positional arg that isn't a flag, flag value, or subcommand
+	const name = args.find(
+		(a, i) =>
+			i > 1 &&
+			!a.startsWith("--") &&
+			!a.startsWith("-") &&
+			!skipSet.has(i) &&
+			a !== "deploy" &&
+			a !== "sleep" &&
+			a !== "wake" &&
+			a !== "status" &&
+			a !== "logs" &&
+			a !== "teardown" &&
+			a !== providerFlag &&
+			a !== nameFlag,
+	)
 	const skipBuild = args.includes("--no-build")
 	const force = args.includes("--force")
 	const follow = !args.includes("--no-follow")
 	return {
 		platform: providerFlag,
-		name: name || posArg || nameFlag,
+		name: name || nameFlag,
 		skipBuild,
 		force,
 		follow,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -58,11 +58,6 @@ async function main() {
 	if (command === "dev") return dev(args.includes("--docker"))
 	if (command === "start") return start()
 	if (command === "deploy") return deployCommand(args)
-	if (command === "deploy:sleep") return deploySleepCommand(args)
-	if (command === "deploy:wake") return deployWakeCommand(args)
-	if (command === "deploy:status") return deployStatusCommand(args)
-	if (command === "deploy:logs") return deployLogsCommand(args)
-	if (command === "deploy:teardown") return deployTeardownCommand(args)
 	if (command === "init") return init(args[1])
 
 	if (command === "owner") {
@@ -131,12 +126,14 @@ async function main() {
 	console.log("  dev                       Start development server")
 	console.log("  build [--target]          Build for deployment (firecracker)")
 	console.log("  start                     Run built agent")
-	console.log("  deploy [platform]         Deploy to a Firecracker provider")
-	console.log("  deploy:sleep <name>       Put VM to sleep")
-	console.log("  deploy:wake <name>        Wake VM")
-	console.log("  deploy:status <name>      Show VM status")
-	console.log("  deploy:logs <name>        Stream agent logs")
-	console.log("  deploy:teardown <name>    Destroy VM")
+	console.log(
+		"  deploy [platform]              Deploy to a Firecracker provider"
+	)
+	console.log("  deploy sleep <name>            Put VM to sleep")
+	console.log("  deploy wake <name>             Wake VM")
+	console.log("  deploy status <name>           Show VM status")
+	console.log("  deploy logs <name>             Stream agent logs")
+	console.log("  deploy teardown <name> [--all] Destroy VM")
 	console.log("")
 	console.log("Deploy flags:")
 	console.log(
@@ -731,78 +728,100 @@ function parseDeployArgs(args: string[]) {
 }
 
 async function deployCommand(args: string[]) {
-	const flags = parseDeployArgs(args)
-	const { runDeploy } = await loadDeploy()
-	await runDeploy(
-		{
-			platform: flags.platform,
-			name: flags.name,
-			skipBuild: flags.skipBuild,
-			force: flags.force
-		},
-		projectRoot,
-		packageDir
+	const sub = args[1]
+
+	// No subcommand — do full deploy
+	if (!sub || sub.startsWith("-")) {
+		const flags = parseDeployArgs(args)
+		const { runDeploy } = await loadDeploy()
+		await runDeploy(
+			{
+				platform: flags.platform,
+				name: flags.name,
+				skipBuild: flags.skipBuild,
+				force: flags.force
+			},
+			projectRoot,
+			packageDir
+		)
+		return
+	}
+
+	const name = args.find((a, i) => i > 1 && !a.startsWith("-"))
+	const platform =
+		args[args.indexOf("--provider") + 1] || args[args.indexOf("-p") + 1]
+
+	switch (sub) {
+		case "sleep": {
+			if (!name) {
+				console.error("Usage: hybrid deploy sleep <name>")
+				process.exit(1)
+			}
+			const { runSleep } = await loadDeploy()
+			await runSleep(name, platform, projectRoot)
+			break
+		}
+		case "wake": {
+			if (!name) {
+				console.error("Usage: hybrid deploy wake <name>")
+				process.exit(1)
+			}
+			const { runWake } = await loadDeploy()
+			await runWake(name, platform, projectRoot)
+			break
+		}
+		case "status": {
+			if (!name) {
+				console.error("Usage: hybrid deploy status <name>")
+				process.exit(1)
+			}
+			const { runStatus } = await loadDeploy()
+			await runStatus(name, platform, projectRoot)
+			break
+		}
+		case "logs": {
+			if (!name) {
+				console.error("Usage: hybrid deploy logs <name>")
+				process.exit(1)
+			}
+			const follow = !args.includes("--no-follow")
+			const { runLogs } = await loadDeploy()
+			await runLogs(name, follow, platform, projectRoot)
+			break
+		}
+		case "teardown": {
+			if (!name) {
+				console.error("Usage: hybrid deploy teardown <name>")
+				process.exit(1)
+			}
+			const { runTeardown } = await loadDeploy()
+			await runTeardown(name, platform, projectRoot)
+			break
+		}
+		default:
+			console.error(`Unknown deploy subcommand: ${sub}`)
+			printDeployHelp()
+			process.exit(1)
+	}
+}
+
+function printDeployHelp() {
+	console.error("")
+	console.error("Usage: hybrid deploy <subcommand>")
+	console.error("")
+	console.error("Commands:")
+	console.error(
+		"  deploy [platform]             Deploy to a Firecracker provider"
 	)
-}
-
-async function deploySleepCommand(args: string[]) {
-	const flags = parseDeployArgs(args)
-	const name = flags.name
-	if (!name) {
-		console.error("Usage: hybrid deploy:sleep <name>")
-		console.error("Flags: --provider <name>, --name <name>")
-		process.exit(1)
-	}
-	const { runSleep } = await loadDeploy()
-	await runSleep(name, flags.platform, projectRoot)
-}
-
-async function deployWakeCommand(args: string[]) {
-	const flags = parseDeployArgs(args)
-	const name = flags.name
-	if (!name) {
-		console.error("Usage: hybrid deploy:wake <name>")
-		console.error("Flags: --provider <name>, --name <name>")
-		process.exit(1)
-	}
-	const { runWake } = await loadDeploy()
-	await runWake(name, flags.platform, projectRoot)
-}
-
-async function deployStatusCommand(args: string[]) {
-	const flags = parseDeployArgs(args)
-	const name = flags.name
-	if (!name) {
-		console.error("Usage: hybrid deploy:status <name>")
-		console.error("Flags: --provider <name>, --name <name>")
-		process.exit(1)
-	}
-	const { runStatus } = await loadDeploy()
-	await runStatus(name, flags.platform, projectRoot)
-}
-
-async function deployLogsCommand(args: string[]) {
-	const flags = parseDeployArgs(args)
-	const name = flags.name
-	if (!name) {
-		console.error("Usage: hybrid deploy:logs <name>")
-		console.error("Flags: --provider <name>, --name <name>, --no-follow")
-		process.exit(1)
-	}
-	const { runLogs } = await loadDeploy()
-	await runLogs(name, flags.follow, flags.platform, projectRoot)
-}
-
-async function deployTeardownCommand(args: string[]) {
-	const flags = parseDeployArgs(args)
-	const name = flags.name
-	if (!name) {
-		console.error("Usage: hybrid deploy:teardown <name>")
-		console.error("Flags: --provider <name>, --name <name>, --all")
-		process.exit(1)
-	}
-	const { runTeardown } = await loadDeploy()
-	await runTeardown(name, flags.platform, projectRoot)
+	console.error("  deploy sleep <name>            Put VM to sleep")
+	console.error("  deploy wake <name>             Wake VM")
+	console.error("  deploy status <name>           Show VM status")
+	console.error("  deploy logs <name>             Stream agent logs")
+	console.error("  deploy teardown <name> [--all] Destroy VM")
+	console.error("")
+	console.error(
+		"Flags: --provider <name>  --name <name>  --force  --no-build  --no-follow"
+	)
 }
 
 // ============================================================================

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -280,7 +280,7 @@ async function init(name?: string) {
 		readdirSync,
 		readFileSync
 	} = await import("node:fs")
-	const { createInterface } = await import("node:readline")
+
 
 	const templateDir = resolve(packageDir, "templates", "agent")
 	const targetDir = resolve(process.cwd(), name)
@@ -340,12 +340,6 @@ async function init(name?: string) {
 	}
 
 	// Collect configuration via prompts
-	const rl = createInterface({
-		input: process.stdin,
-		output: process.stdout
-	})
-
-	// Provider picker using prompts
 	const prompts = (await import("prompts")).default
 	const providerResponse = await prompts({
 		type: "select",
@@ -389,14 +383,12 @@ async function init(name?: string) {
 		version: 1,
 		allowFrom: []
 	}
-	const ownerQuestion = (prompt: string): Promise<string> => {
-		return new Promise((resolve) => {
-			rl.question(prompt, (answer: string) => {
-				resolve(answer.trim())
-			})
-		})
-	}
-	const ownerAddress = await ownerQuestion("\nEnter your wallet address (owner): ")
+	const ownerResponse = await prompts({
+		type: "text",
+		name: "address",
+		message: "Enter your wallet address (owner, optional)"
+	})
+	const ownerAddress = ownerResponse?.address?.trim() || ""
 	if (ownerAddress) {
 		acl.allowFrom.push(ownerAddress.toLowerCase())
 		console.log(`\n✅ Added owner: ${ownerAddress.toLowerCase()}`)
@@ -407,7 +399,7 @@ async function init(name?: string) {
 	)
 
 	// Close readline now that all prompts are done
-	rl.close()
+	// (rl is not used — all prompts use the prompts library now)
 
 	// Update .env file with generated key and API keys
 	let envContent = readFileSync(envPath, "utf-8")
@@ -772,19 +764,28 @@ function parseDeployArgs(args: string[]) {
 async function deployCommand(args: string[]) {
 	const sub = args[1]
 
-	// No subcommand — do full deploy
-	if (!sub || sub.startsWith("-")) {
+	// If sub looks like a known provider, treat it as the platform and deploy.
+	// Otherwise treat it as a subcommand.
+	const knownProviders = new Set([
+		"sprites",
+		"e2b",
+		"daytona",
+		"northflank",
+	])
+	const isPlatform = sub && !sub.startsWith("-") && knownProviders.has(sub)
+
+	if (!sub || sub.startsWith("-") || isPlatform) {
 		const flags = parseDeployArgs(args)
 		const { runDeploy } = await loadDeploy()
 		await runDeploy(
 			{
-				platform: flags.platform,
+				platform: flags.platform || (isPlatform ? sub : undefined),
 				name: flags.name,
 				skipBuild: flags.skipBuild,
-				force: flags.force
+				force: flags.force,
 			},
 			projectRoot,
-			packageDir
+			packageDir,
 		)
 		return
 	}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -137,7 +137,7 @@ async function main() {
 	console.log("")
 	console.log("Deploy flags:")
 	console.log(
-		"  --provider <name>     Override provider (sprites, e2b, daytona)"
+		"  --provider <name>     Override provider (sprites, e2b, daytona, northflank)"
 	)
 	console.log("  --name <name>         Override instance name")
 	console.log("  --force               Recreate VM even if it exists")

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -51,7 +51,10 @@ async function main() {
 	const args = process.argv.slice(2)
 	const command = args[0]
 
-	if (command === "build") return build(args[1])
+	if (command === "build") {
+		const targetFlag = args.indexOf("--target")
+		return build(targetFlag !== -1 ? args[targetFlag + 1] : args[1])
+	}
 	if (command === "dev") return dev(args.includes("--docker"))
 	if (command === "start") return start()
 	if (command === "deploy") return deploy(args[1])
@@ -121,9 +124,9 @@ async function main() {
 	console.log("Commands:")
 	console.log("  init <name>           Initialize a new agent")
 	console.log("  dev                   Start development server")
-	console.log("  build [--target]      Build for deployment (fly, railway)")
+	console.log("  build [--target]      Build for deployment (firecracker)")
 	console.log("  start                 Run built agent")
-	console.log("  deploy [platform]     Deploy (fly, railway)")
+	console.log("  deploy [platform]     Deploy to Firecracker (Sprite)")
 	console.log("")
 	console.log("Owner:")
 	console.log("  owner add <address>     Add an owner")
@@ -337,9 +340,6 @@ async function init(name?: string) {
 		})
 	}
 
-	// Owner wallet address
-	const ownerAddress = await question("\nEnter your wallet address (owner): ")
-
 	rl.close()
 
 	// Provider picker using prompts
@@ -379,17 +379,7 @@ async function init(name?: string) {
 		openrouterKey = keyResponse.key || ""
 	}
 
-	// Create ACL file with owner
-	if (ownerAddress) {
-		const normalized = ownerAddress.toLowerCase()
-		const credentialsDir = resolve(targetDir, "credentials")
-		mkdirSync(credentialsDir, { recursive: true })
-		writeFileSync(
-			resolve(credentialsDir, "allowFrom.json"),
-			JSON.stringify({ version: 1, allowFrom: [normalized] }, null, 2)
-		)
-		console.log(`\n✅ Added owner: ${normalized}`)
-	}
+	// Create ACL file with owner (skip for now)
 
 	// Update .env file with generated key and API keys
 	let envContent = readFileSync(envPath, "utf-8")
@@ -457,7 +447,7 @@ async function build(target?: string) {
 
 	const projectDir = projectRoot
 	const distDir = resolve(projectDir, "dist")
-	const buildTarget = target || "fly"
+	const buildTarget = target || "firecracker"
 
 	console.log("\n🔧 Building agent...")
 
@@ -575,6 +565,57 @@ async function build(target?: string) {
 		} else {
 			writeFileSync(resolve(distDir, "fly.toml"), generateFlyToml())
 		}
+	}
+
+	// Generate deploy.sh for Firecracker (Sprite) deployment
+	if (buildTarget === "firecracker") {
+		const spawnScript = [
+			"#!/bin/bash",
+			"set -e",
+			"",
+			'SPRITE_NAME="${SPRITE_NAME:-hybrid-agent-$(date +%s%N)}"',
+			"",
+			'DIST_DIR="$(cd "$(dirname "$0")" && pwd)"',
+			"",
+			'echo "Deploying to Spawn Sprite: $SPRITE_NAME"',
+			"",
+			"# Create sprite if it doesn't exist",
+			'if ! sprite list 2>/dev/null | grep -q "$SPRITE_NAME"; then',
+			'  echo "Creating sprite: $SPRITE_NAME"',
+			'  sprite create -skip-console "$SPRITE_NAME"',
+			"fi",
+			"",
+			"# Wait for sprite to be ready",
+			'echo "Waiting for sprite to be ready..."',
+			"for i in $(seq 1 30); do",
+			'  if sprite exec -s "$SPRITE_NAME" -- echo ready 2>/dev/null; then',
+			"    break",
+			"  fi",
+			"  sleep 2",
+			"done",
+			"",
+			"# Upload build artifacts",
+			'echo "Uploading build artifacts..."',
+			'tar -czf /tmp/hybrid-deploy.tar.gz -C "$DIST_DIR" .',
+			'sprite exec -s "$SPRITE_NAME" -- mkdir -p /app',
+			'sprite exec -s "$SPRITE_NAME" -file "/tmp/hybrid-deploy.tar.gz:/tmp/hybrid-deploy.tar.gz" -- tar -xzf /tmp/hybrid-deploy.tar.gz -C /app',
+			'rm -f /tmp/hybrid-deploy.tar.gz',
+			"",
+			"# Install dependencies and start agent",
+			"sprite exec -s \"$SPRITE_NAME\" -- bash -c '",
+			"  cd /app",
+			"  npm install --production",
+			"  export NODE_ENV=production",
+			"  export AGENT_PORT=8454",
+			"  exec node server/index.cjs",
+			"'",
+			""
+		].join("\n")
+		writeFileSync(
+			resolve(distDir, "deploy.sh"),
+			spawnScript,
+			{ mode: 0o755 }
+		)
 	}
 
 	// Generate start script
@@ -752,7 +793,7 @@ async function start() {
 // ============================================================================
 
 async function deploy(platform?: string) {
-	const { spawn, execSync } = await import("node:child_process")
+	const { spawn, execSync, execFileSync } = await import("node:child_process")
 	const { existsSync, readFileSync, writeFileSync } = await import("node:fs")
 	const prompts = (await import("prompts")).default
 
@@ -784,8 +825,7 @@ async function deploy(platform?: string) {
 			name: "platform",
 			message: "Where do you want to deploy?",
 			choices: [
-				{ title: "Fly.io", value: "fly" },
-				{ title: "Railway", value: "railway" }
+				{ title: "Firecracker (Sprite)", value: "firecracker" }
 			],
 			initial: 0
 		})
@@ -811,177 +851,204 @@ async function deploy(platform?: string) {
 			writeFileSync(hybridConfig, newContent)
 		}
 	}
+
 	const flyTomlPath = resolve(distDir, "fly.toml")
 	const projectFlyToml = resolve(projectDir, "fly.toml")
 
-	// Get project name from directory as default
-	const projectName = basename(projectDir)
-	let appName = projectName
+	// For firecracker, skip fly-specific checks and go straight to deploy
+	if (deployPlatform === "firecracker") {
+		const projectName = basename(projectDir)
+		const spriteName = process.env.SPRITE_NAME || projectName
 
-	// Check project fly.toml first (preferred)
-	if (existsSync(projectFlyToml)) {
-		const flyToml = readFileSync(projectFlyToml, "utf-8")
-		const match = flyToml.match(/^app\s*=\s*["']([^"']+)["']/m)
-		if (match) appName = match[1]
-	} else {
-		// Prompt for app name only if no project fly.toml exists
-		const result = await prompts({
-			type: "text",
-			name: "appName",
-			message: "App name:",
-			initial: projectName
-		})
-		if (result.appName) appName = result.appName
-	}
+		if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(spriteName)) {
+			console.error(`\n❌ Invalid sprite name: ${spriteName}`)
+			console.error("Name must start with a letter/digit and contain only letters, digits, hyphens, and underscores.")
+			process.exit(1)
+		}
 
-	// Validate app name to prevent command injection
-	if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(appName)) {
-		console.error(`\n❌ Invalid app name: ${appName}`)
-		console.error("App name must start with a letter/digit and contain only letters, digits, hyphens, and underscores.")
-		process.exit(1)
-	}
+		await build("spawn")
 
-	// Check if app exists
-	const { execFileSync } = await import("node:child_process")
-	let appExists = false
-	try {
-		execFileSync("fly", ["status", "--app", appName], { stdio: "pipe" })
-		appExists = true
-	} catch {
-		// App doesn't exist
-	}
+		console.log(`\n🚀 Deploying to Spawn (Sprite)...`)
+		console.log(`   Sprite: ${spriteName}`)
 
-	// Only prompt for secrets on first deploy (when app doesn't exist)
-	// On subsequent deploys, secrets are already set on Fly
-	if (!appExists) {
-		openRouterKey = process.env.OPENROUTER_API_KEY
-		if (!openRouterKey) {
-			console.log("🔑 No OPENROUTER_API_KEY found.")
-			while (true) {
-				const result = await prompts({
-					type: "password",
-					name: "key",
-					message: "Paste OpenRouter API key:"
-				})
-				const key = result.key?.trim()
-				if (key && key.length > 0) {
-					openRouterKey = key
-					break
-				}
-				console.log("   OpenRouter API key is required. Please enter a value.")
+		// Check if sprite already exists
+		let spriteExists = false
+		try {
+			const existingSprites = execFileSync("sprite", ["list"], { encoding: "utf-8" })
+			if (existingSprites.includes(spriteName)) {
+				spriteExists = true
+				console.log(`   Using existing sprite: ${spriteName}`)
 			}
+		} catch {
+			// sprite not installed or other error
 		}
 
-		// Set up owner ACL
-		const aclPath = resolve(projectDir, "credentials", "allowFrom.json")
-		if (!existsSync(aclPath)) {
-			const result = await prompts({
-				type: "text",
-				name: "owner",
-				message: "Your wallet address (owner):",
-				validate: (v: string) =>
-					/^0x[a-fA-F0-9]{40}$/.test(v) ||
-					"Enter a valid Ethereum address (0x...)"
-			})
-			if (result.owner) {
-				const { mkdirSync } = await import("node:fs")
-				mkdirSync(resolve(projectDir, "credentials"), { recursive: true })
-				writeFileSync(
-					aclPath,
-					JSON.stringify(
-						{ version: 1, allowFrom: [result.owner.toLowerCase()] },
-						null,
-						"\t"
-					)
-				)
-				console.log(`✅ Owner set: ${result.owner}\n`)
-			}
-		}
-	}
-
-	// Build first
-	await build(deployPlatform)
-
-	if (deployPlatform === "fly") {
-		console.log("\n🚀 Deploying to Fly.io...")
-
-		// Ensure fly.toml exists with correct app name
-		if (existsSync(projectFlyToml)) {
-			// Copy project fly.toml to dist
-			const { cpSync } = await import("node:fs")
-			cpSync(projectFlyToml, resolve(distDir, "fly.toml"))
-		} else {
-			// Generate fly.toml with correct app name
-			const flyTomlContent = `app = "${appName}"\n\n[build]\n  builder = "paketobuildpacks/builder:base"\n\n[env]\n  PORT = "8454"\n`
-			writeFileSync(resolve(distDir, "fly.toml"), flyTomlContent)
-		}
-
-		if (!appExists) {
-			console.log(`📦 Creating Fly.io app: ${appName}`)
+		// Create sprite if it doesn't exist
+		if (!spriteExists) {
+			console.log(`\n📦 Creating sprite: ${spriteName}`)
 			try {
-				execFileSync("fly", ["apps", "create", appName], {
-					cwd: distDir,
+				execFileSync("sprite", ["create", "-skip-console", spriteName], {
 					stdio: "inherit"
 				})
 			} catch {
-				console.log(`   App may already exist, continuing...`)
+				// Sprite may already exist (race condition or cached)
+				console.log(`   Sprite ${spriteName} already exists, using it`)
 			}
 		}
 
-		// Deploy
-		await new Promise<void>((resolve, reject) => {
-			const deploy = spawn("fly", ["deploy", "--config", "fly.toml"], {
-				cwd: distDir,
-				stdio: "inherit"
-			})
-			deploy.on("error", (err) =>
-				reject(new Error(`Deploy failed: ${err.message}`))
-			)
-			deploy.on("close", (code) =>
-				code === 0 ? resolve() : reject(new Error(`Exit ${code}`))
-			)
+		// Wait for sprite to be ready
+		console.log("\n⏳ Waiting for sprite to be ready...")
+		let ready = false
+		for (let i = 0; i < 30; i++) {
+			try {
+				execFileSync("sprite", ["exec", "-s", spriteName, "--", "echo", "ready"], {
+					stdio: "pipe"
+				})
+				ready = true
+				break
+			} catch {
+				if (i % 5 === 4) {
+					console.log(`   Still waiting... (${i + 1}/30)`)
+				}
+				await new Promise((r) => setTimeout(r, 2000))
+			}
+		}
+
+		if (!ready) {
+			console.error("\n❌ Sprite did not become ready in time.")
+			process.exit(1)
+		}
+
+		console.log("   ✓ Sprite ready")
+
+		// Upload build artifacts
+		console.log("\n📤 Uploading build artifacts...")
+		const { tmpdir } = await import("node:os")
+		const { join } = await import("node:path")
+		const tarPath = join(tmpdir(), `hybrid-deploy-${Date.now()}.tar.gz`)
+
+		execFileSync("tar", ["-czf", tarPath, "-C", distDir, "."], {
+			stdio: "pipe"
 		})
 
-		// Set secrets via fly secrets (doesn't require VM to be running)
-		if (!appExists) {
-			if (openRouterKey) {
-				console.log("\n🔑 Setting OpenRouter key as secret...")
-				try {
-					execFileSync(
-						"fly",
-						["secrets", "set", `OPENROUTER_API_KEY=${openRouterKey}`, "--app", appName],
-						{
-							cwd: distDir,
-							stdio: "inherit"
-						}
-					)
-				} catch (e) {
-					console.log("   ⚠️  Could not set secret, skipping...")
+		execFileSync("sprite", ["exec", "-s", spriteName, "--", "mkdir", "-p", "/app"], {
+			stdio: "pipe"
+		})
+
+		// Retry upload up to 3 times (sprite may still be initializing)
+		let uploadSuccess = false
+		for (let attempt = 0; attempt < 3; attempt++) {
+			try {
+				execFileSync(
+					"sprite",
+					[
+						"exec",
+						"-s",
+						spriteName,
+						"-file",
+						`${tarPath}:/tmp/hybrid-deploy.tar.gz`,
+						"--",
+						"tar",
+						"-xzf",
+						"/tmp/hybrid-deploy.tar.gz",
+						"-C",
+						"/app"
+					],
+					{ stdio: "inherit" }
+				)
+				uploadSuccess = true
+				break
+			} catch {
+				if (attempt < 2) {
+					console.log(`   Upload failed, retrying... (${attempt + 1}/3)`)
+					await new Promise((r) => setTimeout(r, 5000))
 				}
 			}
 		}
 
-		console.log("\n✅ Deployed!")
-		console.log(`   Dashboard: https://fly.io/apps/${appName}`)
-
-		// Save fly.toml to project for future deploys
-		if (!existsSync(projectFlyToml)) {
-			const { cpSync } = await import("node:fs")
-			cpSync(resolve(distDir, "fly.toml"), projectFlyToml)
-			console.log(`   Saved fly.toml to project`)
+		if (!uploadSuccess) {
+			console.error("\n❌ Failed to upload build artifacts after 3 attempts.")
+			process.exit(1)
 		}
 
+		// Clean up local tar
+		try {
+			const { unlinkSync } = await import("node:fs")
+			unlinkSync(tarPath)
+		} catch {}
+
+		// Install dependencies
+		console.log("\n📦 Installing dependencies...")
+		execFileSync(
+			"sprite",
+			["exec", "-s", spriteName, "--", "bash", "-c", "cd /app && npm install --production"],
+			{ stdio: "inherit" }
+		)
+
+		// Create startup script
+		console.log("\n🔧 Setting up agent service...")
+		const startupScript = `#!/bin/bash
+cd /app
+export NODE_ENV=production
+export AGENT_PORT=8454
+export OPENROUTER_API_KEY=${openRouterKey || process.env.OPENROUTER_API_KEY || ""}
+exec nohup node server/index.cjs > /app/agent.log 2>&1 &
+echo $! > /app/agent.pid
+`
+		const { tmpdir: osTmpdir } = await import("node:os")
+		const { join: pathJoin } = await import("node:path")
+		const scriptPath = osTmpdir() + `/hybrid-start-${Date.now()}.sh`
+		writeFileSync(scriptPath, startupScript, { mode: 0o755 })
+
+		execFileSync(
+			"sprite",
+			["exec", "-s", spriteName, "-file", `${scriptPath}:/app/start-agent.sh`, "--", "chmod", "+x", "/app/start-agent.sh"],
+			{ stdio: "pipe" }
+		)
+
+		execFileSync(
+			"sprite",
+			["exec", "-s", spriteName, "--", "bash", "/app/start-agent.sh"],
+			{ stdio: "inherit" }
+		)
+
+		try {
+			const { unlinkSync } = await import("node:fs")
+			unlinkSync(scriptPath)
+		} catch {}
+
+		// Wait for agent to start
+		console.log("\n⏳ Waiting for agent to start...")
+		let agentReady = false
+		for (let i = 0; i < 15; i++) {
+			try {
+				const result = execFileSync(
+					"sprite",
+					["exec", "-s", spriteName, "--", "curl", "-s", "http://localhost:8454/health"],
+					{ encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+				)
+				if (result) {
+					agentReady = true
+					break
+				}
+			} catch {
+				// Agent not ready yet
+			}
+			await new Promise((r) => setTimeout(r, 2000))
+		}
+
+		console.log(`\n   Sprite: ${spriteName}`)
+		console.log(`   URL: https://${spriteName}.sprites.dev`)
+		console.log(`   Health: https://${spriteName}.sprites.dev/health`)
+		console.log(`   Chat: https://${spriteName}.sprites.dev/api/chat`)
+		console.log("\n✅ Deployed!")
+		console.log("\nConnect to the running agent:")
+		console.log(`   sprite exec -s ${spriteName} -tty -- bash`)
 		return
 	}
 
-	if (deployPlatform === "railway") {
-		console.log("\n🚂 Railway deployment not yet implemented.")
-		console.log("   See https://railway.app for manual deployment.")
-		process.exit(1)
-	}
-
 	console.error(`Unknown platform: ${deployPlatform}`)
-	console.error("Supported: fly, railway")
+	console.error("Supported: firecracker")
 	process.exit(1)
 }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -136,9 +136,7 @@ async function main() {
 	console.log("  deploy teardown <name> [--all] Destroy VM")
 	console.log("")
 	console.log("Deploy flags:")
-	console.log(
-		"  --provider <name>     Override provider (sprites, e2b, daytona, northflank)"
-	)
+	console.log("  --provider <name>  Override provider (sprites, e2b, northflank, daytona)")
 	console.log("  --name <name>         Override instance name")
 	console.log("  --force               Recreate VM even if it exists")
 	console.log("  --no-build            Skip build step")

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -574,8 +574,8 @@ async function build(target?: string) {
 		JSON.stringify(deployPkg, null, 2)
 	)
 
-	// Generate Dockerfile (generic Firecracker target)
-	writeFileSync(resolve(distDir, "Dockerfile"), generateDockerfile())
+	// Generate Dockerfile (only COPY files that exist in dist)
+	writeFileSync(resolve(distDir, "Dockerfile"), generateDockerfile(distDir))
 
 	// .hybrid-deploy.json manifest for provider consumption
 	writeFileSync(
@@ -606,14 +606,31 @@ node server/index.cjs
 	console.log(`   Target: ${buildTarget}`)
 }
 
-function generateDockerfile(): string {
+function generateDockerfile(distDir: string): string {
+	const configFiles = [
+		"SOUL.md",
+		"AGENTS.md",
+		"IDENTITY.md",
+		"TOOLS.md",
+		"BOOT.md",
+		"BOOTSTRAP.md",
+		"HEARTBEAT.md",
+		"USER.md",
+	]
+	const present = configFiles.filter((f) =>
+		existsSync(resolve(distDir, f)),
+	)
+	const hasCredentials = existsSync(resolve(distDir, "credentials"))
+	const configCopy = present.length > 0 ? `COPY ${present.join(" ")} ./` : ""
+	const credCopy = hasCredentials ? "COPY credentials/ ./credentials/" : ""
+
 	return `FROM node:20-bookworm-slim
 WORKDIR /app
 COPY package.json ./
 RUN npm install --production
 COPY server/ ./server/
-COPY SOUL.md AGENTS.md IDENTITY.md TOOLS.md BOOT.md BOOTSTRAP.md HEARTBEAT.md USER.md ./
-COPY credentials/ ./credentials/
+${configCopy}
+${credCopy}
 ENV AGENT_PORT=8454
 ENV NODE_ENV=production
 ENV DATA_ROOT=/app/data

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -621,7 +621,7 @@ COPY package.json ./
 RUN npm install --production
 COPY server/ ./server/
 COPY SOUL.md AGENTS.md IDENTITY.md TOOLS.md BOOT.md BOOTSTRAP.md HEARTBEAT.md USER.md ./
-COPY credentials/ ./credentials/ 2>/dev/null || true
+COPY credentials/ ./credentials/
 ENV AGENT_PORT=8454
 ENV NODE_ENV=production
 ENV DATA_ROOT=/app/data
@@ -717,17 +717,15 @@ async function loadDeploy() {
 function parseDeployArgs(args: string[]) {
 	// Collect known flag indices so we don't mistake flag values as positional names
 	const skipSet = new Set<number>()
-	const flagNames = [
+	// Only flags that consume a value should skip the NEXT index
+	const valuedFlags = new Set([
 		"--provider",
 		"-p",
 		"--name",
 		"-n",
-		"--no-build",
-		"--force",
-		"--no-follow",
-	]
+	])
 	for (let i = 0; i < args.length; i++) {
-		if (flagNames.includes(args[i])) {
+		if (valuedFlags.has(args[i])) {
 			skipSet.add(i)
 			skipSet.add(i + 1)
 		}
@@ -791,12 +789,26 @@ async function deployCommand(args: string[]) {
 		return
 	}
 
-	const name = args.find((a, i) => i > 1 && !a.startsWith("-"))
 	const pIdx = args.indexOf("--provider")
 	const pAlt = args.indexOf("-p")
+	const nIdx = args.indexOf("--name")
+	const nAlt = args.indexOf("-n")
 	const subPlatform =
 		(pIdx !== -1 ? args[pIdx + 1] : undefined) ||
 		(pAlt !== -1 ? args[pAlt + 1] : undefined)
+	const subSkipIdx = new Set<number>()
+	subSkipIdx.add(pIdx)
+	subSkipIdx.add(pAlt)
+	subSkipIdx.add(nIdx)
+	subSkipIdx.add(nAlt)
+	// Skip the values after valued flags too
+	if (pIdx !== -1) subSkipIdx.add(pIdx + 1)
+	if (pAlt !== -1) subSkipIdx.add(pAlt + 1)
+	if (nIdx !== -1) subSkipIdx.add(nIdx + 1)
+	if (nAlt !== -1) subSkipIdx.add(nAlt + 1)
+	const name = args.find(
+		(a, i) => i > 1 && !a.startsWith("-") && !subSkipIdx.has(i),
+	)
 
 	switch (sub) {
 		case "sleep": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -392,7 +392,29 @@ async function init(name?: string) {
 		openrouterKey = keyResponse.key || ""
 	}
 
-	// Create ACL file with owner (skip for now)
+	// Create ACL file with owner
+	const credentialsDir = resolve(targetDir, "credentials")
+	mkdirSync(credentialsDir, { recursive: true })
+	const acl: { version: number; allowFrom: string[] } = {
+		version: 1,
+		allowFrom: []
+	}
+	const ownerQuestion = (prompt: string): Promise<string> => {
+		return new Promise((resolve) => {
+			rl.question(prompt, (answer: string) => {
+				resolve(answer.trim())
+			})
+		})
+	}
+	const ownerAddress = await ownerQuestion("\nEnter your wallet address (owner): ")
+	if (ownerAddress) {
+		acl.allowFrom.push(ownerAddress.toLowerCase())
+		console.log(`\n✅ Added owner: ${ownerAddress.toLowerCase()}`)
+	}
+	writeFileSync(
+		resolve(credentialsDir, "allowFrom.json"),
+		JSON.stringify(acl, null, 2)
+	)
 
 	// Update .env file with generated key and API keys
 	let envContent = readFileSync(envPath, "utf-8")

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync } from "node:fs"
-import { basename, dirname, resolve } from "node:path"
+import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { config } from "dotenv"
 
@@ -57,7 +57,12 @@ async function main() {
 	}
 	if (command === "dev") return dev(args.includes("--docker"))
 	if (command === "start") return start()
-	if (command === "deploy") return deploy(args[1])
+	if (command === "deploy") return deployCommand(args)
+	if (command === "deploy:sleep") return deploySleepCommand(args)
+	if (command === "deploy:wake") return deployWakeCommand(args)
+	if (command === "deploy:status") return deployStatusCommand(args)
+	if (command === "deploy:logs") return deployLogsCommand(args)
+	if (command === "deploy:teardown") return deployTeardownCommand(args)
 	if (command === "init") return init(args[1])
 
 	if (command === "owner") {
@@ -122,11 +127,24 @@ async function main() {
 	console.log("Usage: hybrid <command>")
 	console.log("")
 	console.log("Commands:")
-	console.log("  init <name>           Initialize a new agent")
-	console.log("  dev                   Start development server")
-	console.log("  build [--target]      Build for deployment (firecracker)")
-	console.log("  start                 Run built agent")
-	console.log("  deploy [platform]     Deploy to Firecracker (Sprite)")
+	console.log("  init <name>               Initialize a new agent")
+	console.log("  dev                       Start development server")
+	console.log("  build [--target]          Build for deployment (firecracker)")
+	console.log("  start                     Run built agent")
+	console.log("  deploy [platform]         Deploy to a Firecracker provider")
+	console.log("  deploy:sleep <name>       Put VM to sleep")
+	console.log("  deploy:wake <name>        Wake VM")
+	console.log("  deploy:status <name>      Show VM status")
+	console.log("  deploy:logs <name>        Stream agent logs")
+	console.log("  deploy:teardown <name>    Destroy VM")
+	console.log("")
+	console.log("Deploy flags:")
+	console.log(
+		"  --provider <name>     Override provider (sprites, e2b, daytona)"
+	)
+	console.log("  --name <name>         Override instance name")
+	console.log("  --force               Recreate VM even if it exists")
+	console.log("  --no-build            Skip build step")
 	console.log("")
 	console.log("Owner:")
 	console.log("  owner add <address>     Add an owner")
@@ -539,9 +557,9 @@ async function build(target?: string) {
 		version: "1.0.0",
 		type: "module",
 		dependencies: {
-		"@anthropic-ai/claude-agent-sdk": "^0.2.38",
-		"@hono/node-server": "^1.13.5",
-		ai: "^6.0.0",
+			"@anthropic-ai/claude-agent-sdk": "^0.2.38",
+			"@hono/node-server": "^1.13.5",
+			ai: "^6.0.0",
 			"better-sqlite3": "^11.0.0",
 			dotenv: "^16.4.5",
 			hono: "^4.10.8",
@@ -554,69 +572,24 @@ async function build(target?: string) {
 		JSON.stringify(deployPkg, null, 2)
 	)
 
-	// Generate Dockerfile
-	writeFileSync(resolve(distDir, "Dockerfile"), generateDockerfile(buildTarget))
+	// Generate Dockerfile (generic Firecracker target)
+	writeFileSync(resolve(distDir, "Dockerfile"), generateDockerfile())
 
-	// Copy or generate fly.toml
-	if (buildTarget === "fly") {
-		const projectFlyToml = resolve(projectDir, "fly.toml")
-		if (existsSync(projectFlyToml)) {
-			cpSync(projectFlyToml, resolve(distDir, "fly.toml"))
-		} else {
-			writeFileSync(resolve(distDir, "fly.toml"), generateFlyToml())
-		}
-	}
-
-	// Generate deploy.sh for Firecracker (Sprite) deployment
-	if (buildTarget === "firecracker") {
-		const spawnScript = [
-			"#!/bin/bash",
-			"set -e",
-			"",
-			'SPRITE_NAME="${SPRITE_NAME:-hybrid-agent-$(date +%s%N)}"',
-			"",
-			'DIST_DIR="$(cd "$(dirname "$0")" && pwd)"',
-			"",
-			'echo "Deploying to Spawn Sprite: $SPRITE_NAME"',
-			"",
-			"# Create sprite if it doesn't exist",
-			'if ! sprite list 2>/dev/null | grep -q "$SPRITE_NAME"; then',
-			'  echo "Creating sprite: $SPRITE_NAME"',
-			'  sprite create -skip-console "$SPRITE_NAME"',
-			"fi",
-			"",
-			"# Wait for sprite to be ready",
-			'echo "Waiting for sprite to be ready..."',
-			"for i in $(seq 1 30); do",
-			'  if sprite exec -s "$SPRITE_NAME" -- echo ready 2>/dev/null; then',
-			"    break",
-			"  fi",
-			"  sleep 2",
-			"done",
-			"",
-			"# Upload build artifacts",
-			'echo "Uploading build artifacts..."',
-			'tar -czf /tmp/hybrid-deploy.tar.gz -C "$DIST_DIR" .',
-			'sprite exec -s "$SPRITE_NAME" -- mkdir -p /app',
-			'sprite exec -s "$SPRITE_NAME" -file "/tmp/hybrid-deploy.tar.gz:/tmp/hybrid-deploy.tar.gz" -- tar -xzf /tmp/hybrid-deploy.tar.gz -C /app',
-			'rm -f /tmp/hybrid-deploy.tar.gz',
-			"",
-			"# Install dependencies and start agent",
-			"sprite exec -s \"$SPRITE_NAME\" -- bash -c '",
-			"  cd /app",
-			"  npm install --production",
-			"  export NODE_ENV=production",
-			"  export AGENT_PORT=8454",
-			"  exec node server/index.cjs",
-			"'",
-			""
-		].join("\n")
-		writeFileSync(
-			resolve(distDir, "deploy.sh"),
-			spawnScript,
-			{ mode: 0o755 }
+	// .hybrid-deploy.json manifest for provider consumption
+	writeFileSync(
+		resolve(distDir, ".hybrid-deploy.json"),
+		JSON.stringify(
+			{
+				version: 1,
+				provider: "firecracker",
+				startCommand: "node server/index.cjs",
+				port: 8454,
+				healthPath: "/health"
+			},
+			null,
+			2
 		)
-	}
+	)
 
 	// Generate start script
 	writeFileSync(
@@ -631,89 +604,20 @@ node server/index.cjs
 	console.log(`   Target: ${buildTarget}`)
 }
 
-function generateDockerfile(target: string): string {
-	if (target === "fly" || target === "railway") {
-		return `FROM node:20
-
+function generateDockerfile(): string {
+	return `FROM node:20-bookworm-slim
 WORKDIR /app
-
-# Copy built agent runtime
-COPY server/ ./server/
-
-# Copy config
-COPY SOUL.md ./
-COPY AGENTS.md ./
-COPY IDENTITY.md ./
-COPY TOOLS.md ./
-COPY BOOTSTRAP.md ./
-COPY HEARTBEAT.md ./
-COPY USER.md ./
-
-# Copy credentials (owner ACL)
-COPY credentials/ ./credentials/
-
-# Copy deployment files
 COPY package.json ./
-COPY start.sh ./
-
-# Install dependencies
 RUN npm install --production
-
-# Create data directories and set ownership
-RUN chown -R node:node /app
-
+COPY server/ ./server/
+COPY SOUL.md AGENTS.md IDENTITY.md TOOLS.md BOOT.md BOOTSTRAP.md HEARTBEAT.md USER.md ./
+COPY credentials/ ./credentials/ 2>/dev/null || true
 ENV AGENT_PORT=8454
 ENV NODE_ENV=production
+ENV DATA_ROOT=/app/data
 EXPOSE 8454
-
 USER node
 CMD ["node", "server/index.cjs"]
-`
-	}
-
-	return `FROM node:20
-WORKDIR /app
-COPY . ./
-RUN npm install --production
-RUN chown -R node:node /app
-USER node
-CMD ["sh", "start.sh"]
-`
-}
-
-function generateFlyToml(appName = "hybrid-agent"): string {
-	return `# Generated by hybrid build
-app = "${appName}"
-primary_region = "iad"
-
-[build]
-  dockerfile = "Dockerfile"
-  context = "."
-
-[deployment]
-  min_machines = 1
-  max_machines = 1
-
-[env]
-  NODE_ENV = "production"
-
-[[services]]
-  protocol = "tcp"
-  internal_port = 8454
-
-  [[services.ports]]
-    port = 80
-    handlers = ["http"]
-    force_https = true
-
-  [[services.ports]]
-    port = 443
-    handlers = ["tls", "http"]
-
-[vm]
-  memory = "1gb"
-  cpu_kind = "shared"
-  cpus = 1
 `
 }
 
@@ -789,267 +693,116 @@ async function start() {
 }
 
 // ============================================================================
-// Deploy
+// Deploy — delegates to deploy/ providers
 // ============================================================================
 
-async function deploy(platform?: string) {
-	const { spawn, execSync, execFileSync } = await import("node:child_process")
-	const { existsSync, readFileSync, writeFileSync } = await import("node:fs")
-	const prompts = (await import("prompts")).default
-
-	const projectDir = projectRoot
-	let openRouterKey: string | undefined
-	const distDir = resolve(projectDir, "dist")
-
-	// Prompt for platform if not specified
-	let deployPlatform = platform
-
-	// Check hybrid.config.ts for saved platform
-	if (!deployPlatform) {
-		const hybridConfig = resolve(projectDir, "hybrid.config.ts")
-		if (existsSync(hybridConfig)) {
-			const configContent = readFileSync(hybridConfig, "utf-8")
-			const match = configContent.match(
-				/deployPlatform\s*[=:]\s*["']([^"']+)["']/
-			)
-			if (match) {
-				deployPlatform = match[1]
-				console.log(`   Using saved platform: ${deployPlatform}`)
-			}
-		}
+let deployModule: typeof import("./deploy/deploy") | null = null
+async function loadDeploy() {
+	if (!deployModule) {
+		deployModule = await import("./deploy/deploy")
 	}
+	return deployModule
+}
 
-	if (!deployPlatform) {
-		const choice = await prompts({
-			type: "select",
-			name: "platform",
-			message: "Where do you want to deploy?",
-			choices: [
-				{ title: "Firecracker (Sprite)", value: "firecracker" }
-			],
-			initial: 0
-		})
-		if (!choice.platform) {
-			console.log("\n  Cancelled.\n")
-			process.exit(0)
-		}
-		deployPlatform = choice.platform
-
-		// Save platform to hybrid.config.ts
-		const hybridConfig = resolve(projectDir, "hybrid.config.ts")
-		let configContent = ""
-		if (existsSync(hybridConfig)) {
-			configContent = readFileSync(hybridConfig, "utf-8")
-		}
-		if (!configContent.includes("deployPlatform")) {
-			const newContent = configContent
-				? configContent.replace(
-						/export default/,
-						`const deployPlatform = "${deployPlatform}"\n\nexport default`
-					)
-				: `const deployPlatform = "${deployPlatform}"\n\nexport default {}`
-			writeFileSync(hybridConfig, newContent)
-		}
+function parseDeployArgs(args: string[]) {
+	const name = args.find(
+		(a, i) => i > 1 && !a.startsWith("--") && !a.startsWith("-")
+	)
+	const platform = args.find(
+		(a, i) =>
+			(i > 1 && a.endsWith(":") === false && args[i - 1] === "--provider") ||
+			(i > 1 && args[i - 1] === "-p")
+	)
+	const providerFlag =
+		args[args.indexOf("--provider") + 1] || args[args.indexOf("-p") + 1]
+	const nameFlag =
+		args[args.indexOf("--name") + 1] || args[args.indexOf("-n") + 1]
+	const skipBuild = args.includes("--no-build")
+	const force = args.includes("--force")
+	const posArg = args[1] && !args[1].startsWith("-") ? args[1] : undefined
+	const follow = !args.includes("--no-follow")
+	return {
+		platform: providerFlag,
+		name: nameFlag || posArg,
+		skipBuild,
+		force,
+		follow
 	}
+}
 
-	const flyTomlPath = resolve(distDir, "fly.toml")
-	const projectFlyToml = resolve(projectDir, "fly.toml")
+async function deployCommand(args: string[]) {
+	const flags = parseDeployArgs(args)
+	const { runDeploy } = await loadDeploy()
+	await runDeploy(
+		{
+			platform: flags.platform,
+			name: flags.name,
+			skipBuild: flags.skipBuild,
+			force: flags.force
+		},
+		projectRoot,
+		packageDir
+	)
+}
 
-	// For firecracker, skip fly-specific checks and go straight to deploy
-	if (deployPlatform === "firecracker") {
-		const projectName = basename(projectDir)
-		const spriteName = process.env.SPRITE_NAME || projectName
-
-		if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(spriteName)) {
-			console.error(`\n❌ Invalid sprite name: ${spriteName}`)
-			console.error("Name must start with a letter/digit and contain only letters, digits, hyphens, and underscores.")
-			process.exit(1)
-		}
-
-		await build("spawn")
-
-		console.log(`\n🚀 Deploying to Spawn (Sprite)...`)
-		console.log(`   Sprite: ${spriteName}`)
-
-		// Check if sprite already exists
-		let spriteExists = false
-		try {
-			const existingSprites = execFileSync("sprite", ["list"], { encoding: "utf-8" })
-			if (existingSprites.includes(spriteName)) {
-				spriteExists = true
-				console.log(`   Using existing sprite: ${spriteName}`)
-			}
-		} catch {
-			// sprite not installed or other error
-		}
-
-		// Create sprite if it doesn't exist
-		if (!spriteExists) {
-			console.log(`\n📦 Creating sprite: ${spriteName}`)
-			try {
-				execFileSync("sprite", ["create", "-skip-console", spriteName], {
-					stdio: "inherit"
-				})
-			} catch {
-				// Sprite may already exist (race condition or cached)
-				console.log(`   Sprite ${spriteName} already exists, using it`)
-			}
-		}
-
-		// Wait for sprite to be ready
-		console.log("\n⏳ Waiting for sprite to be ready...")
-		let ready = false
-		for (let i = 0; i < 30; i++) {
-			try {
-				execFileSync("sprite", ["exec", "-s", spriteName, "--", "echo", "ready"], {
-					stdio: "pipe"
-				})
-				ready = true
-				break
-			} catch {
-				if (i % 5 === 4) {
-					console.log(`   Still waiting... (${i + 1}/30)`)
-				}
-				await new Promise((r) => setTimeout(r, 2000))
-			}
-		}
-
-		if (!ready) {
-			console.error("\n❌ Sprite did not become ready in time.")
-			process.exit(1)
-		}
-
-		console.log("   ✓ Sprite ready")
-
-		// Upload build artifacts
-		console.log("\n📤 Uploading build artifacts...")
-		const { tmpdir } = await import("node:os")
-		const { join } = await import("node:path")
-		const tarPath = join(tmpdir(), `hybrid-deploy-${Date.now()}.tar.gz`)
-
-		execFileSync("tar", ["-czf", tarPath, "-C", distDir, "."], {
-			stdio: "pipe"
-		})
-
-		execFileSync("sprite", ["exec", "-s", spriteName, "--", "mkdir", "-p", "/app"], {
-			stdio: "pipe"
-		})
-
-		// Retry upload up to 3 times (sprite may still be initializing)
-		let uploadSuccess = false
-		for (let attempt = 0; attempt < 3; attempt++) {
-			try {
-				execFileSync(
-					"sprite",
-					[
-						"exec",
-						"-s",
-						spriteName,
-						"-file",
-						`${tarPath}:/tmp/hybrid-deploy.tar.gz`,
-						"--",
-						"tar",
-						"-xzf",
-						"/tmp/hybrid-deploy.tar.gz",
-						"-C",
-						"/app"
-					],
-					{ stdio: "inherit" }
-				)
-				uploadSuccess = true
-				break
-			} catch {
-				if (attempt < 2) {
-					console.log(`   Upload failed, retrying... (${attempt + 1}/3)`)
-					await new Promise((r) => setTimeout(r, 5000))
-				}
-			}
-		}
-
-		if (!uploadSuccess) {
-			console.error("\n❌ Failed to upload build artifacts after 3 attempts.")
-			process.exit(1)
-		}
-
-		// Clean up local tar
-		try {
-			const { unlinkSync } = await import("node:fs")
-			unlinkSync(tarPath)
-		} catch {}
-
-		// Install dependencies
-		console.log("\n📦 Installing dependencies...")
-		execFileSync(
-			"sprite",
-			["exec", "-s", spriteName, "--", "bash", "-c", "cd /app && npm install --production"],
-			{ stdio: "inherit" }
-		)
-
-		// Create startup script
-		console.log("\n🔧 Setting up agent service...")
-		const startupScript = `#!/bin/bash
-cd /app
-export NODE_ENV=production
-export AGENT_PORT=8454
-export OPENROUTER_API_KEY=${openRouterKey || process.env.OPENROUTER_API_KEY || ""}
-exec nohup node server/index.cjs > /app/agent.log 2>&1 &
-echo $! > /app/agent.pid
-`
-		const { tmpdir: osTmpdir } = await import("node:os")
-		const { join: pathJoin } = await import("node:path")
-		const scriptPath = osTmpdir() + `/hybrid-start-${Date.now()}.sh`
-		writeFileSync(scriptPath, startupScript, { mode: 0o755 })
-
-		execFileSync(
-			"sprite",
-			["exec", "-s", spriteName, "-file", `${scriptPath}:/app/start-agent.sh`, "--", "chmod", "+x", "/app/start-agent.sh"],
-			{ stdio: "pipe" }
-		)
-
-		execFileSync(
-			"sprite",
-			["exec", "-s", spriteName, "--", "bash", "/app/start-agent.sh"],
-			{ stdio: "inherit" }
-		)
-
-		try {
-			const { unlinkSync } = await import("node:fs")
-			unlinkSync(scriptPath)
-		} catch {}
-
-		// Wait for agent to start
-		console.log("\n⏳ Waiting for agent to start...")
-		let agentReady = false
-		for (let i = 0; i < 15; i++) {
-			try {
-				const result = execFileSync(
-					"sprite",
-					["exec", "-s", spriteName, "--", "curl", "-s", "http://localhost:8454/health"],
-					{ encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
-				)
-				if (result) {
-					agentReady = true
-					break
-				}
-			} catch {
-				// Agent not ready yet
-			}
-			await new Promise((r) => setTimeout(r, 2000))
-		}
-
-		console.log(`\n   Sprite: ${spriteName}`)
-		console.log(`   URL: https://${spriteName}.sprites.dev`)
-		console.log(`   Health: https://${spriteName}.sprites.dev/health`)
-		console.log(`   Chat: https://${spriteName}.sprites.dev/api/chat`)
-		console.log("\n✅ Deployed!")
-		console.log("\nConnect to the running agent:")
-		console.log(`   sprite exec -s ${spriteName} -tty -- bash`)
-		return
+async function deploySleepCommand(args: string[]) {
+	const flags = parseDeployArgs(args)
+	const name = flags.name
+	if (!name) {
+		console.error("Usage: hybrid deploy:sleep <name>")
+		console.error("Flags: --provider <name>, --name <name>")
+		process.exit(1)
 	}
+	const { runSleep } = await loadDeploy()
+	await runSleep(name, flags.platform, projectRoot)
+}
 
-	console.error(`Unknown platform: ${deployPlatform}`)
-	console.error("Supported: firecracker")
-	process.exit(1)
+async function deployWakeCommand(args: string[]) {
+	const flags = parseDeployArgs(args)
+	const name = flags.name
+	if (!name) {
+		console.error("Usage: hybrid deploy:wake <name>")
+		console.error("Flags: --provider <name>, --name <name>")
+		process.exit(1)
+	}
+	const { runWake } = await loadDeploy()
+	await runWake(name, flags.platform, projectRoot)
+}
+
+async function deployStatusCommand(args: string[]) {
+	const flags = parseDeployArgs(args)
+	const name = flags.name
+	if (!name) {
+		console.error("Usage: hybrid deploy:status <name>")
+		console.error("Flags: --provider <name>, --name <name>")
+		process.exit(1)
+	}
+	const { runStatus } = await loadDeploy()
+	await runStatus(name, flags.platform, projectRoot)
+}
+
+async function deployLogsCommand(args: string[]) {
+	const flags = parseDeployArgs(args)
+	const name = flags.name
+	if (!name) {
+		console.error("Usage: hybrid deploy:logs <name>")
+		console.error("Flags: --provider <name>, --name <name>, --no-follow")
+		process.exit(1)
+	}
+	const { runLogs } = await loadDeploy()
+	await runLogs(name, flags.follow, flags.platform, projectRoot)
+}
+
+async function deployTeardownCommand(args: string[]) {
+	const flags = parseDeployArgs(args)
+	const name = flags.name
+	if (!name) {
+		console.error("Usage: hybrid deploy:teardown <name>")
+		console.error("Flags: --provider <name>, --name <name>, --all")
+		process.exit(1)
+	}
+	const { runTeardown } = await loadDeploy()
+	await runTeardown(name, flags.platform, projectRoot)
 }
 
 // ============================================================================

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -345,16 +345,6 @@ async function init(name?: string) {
 		output: process.stdout
 	})
 
-	const question = (prompt: string): Promise<string> => {
-		return new Promise((resolve) => {
-			rl.question(prompt, (answer: string) => {
-				resolve(answer.trim())
-			})
-		})
-	}
-
-	rl.close()
-
 	// Provider picker using prompts
 	const prompts = (await import("prompts")).default
 	const providerResponse = await prompts({
@@ -415,6 +405,9 @@ async function init(name?: string) {
 		resolve(credentialsDir, "allowFrom.json"),
 		JSON.stringify(acl, null, 2)
 	)
+
+	// Close readline now that all prompts are done
+	rl.close()
 
 	// Update .env file with generated key and API keys
 	let envContent = readFileSync(envPath, "utf-8")
@@ -723,27 +716,29 @@ async function loadDeploy() {
 
 function parseDeployArgs(args: string[]) {
 	const name = args.find(
-		(a, i) => i > 1 && !a.startsWith("--") && !a.startsWith("-")
+		(a, i) => i > 1 && !a.startsWith("--") && !a.startsWith("-"),
 	)
-	const platform = args.find(
-		(a, i) =>
-			(i > 1 && a.endsWith(":") === false && args[i - 1] === "--provider") ||
-			(i > 1 && args[i - 1] === "-p")
-	)
+	const providerIdx = args.indexOf("--provider")
+	const providerAltIdx = args.indexOf("-p")
+	const nameIdx = args.indexOf("--name")
+	const nameAltIdx = args.indexOf("-n")
 	const providerFlag =
-		args[args.indexOf("--provider") + 1] || args[args.indexOf("-p") + 1]
+		(providerIdx !== -1 ? args[providerIdx + 1] : undefined) ||
+		(providerAltIdx !== -1 ? args[providerAltIdx + 1] : undefined)
 	const nameFlag =
-		args[args.indexOf("--name") + 1] || args[args.indexOf("-n") + 1]
+		(nameIdx !== -1 ? args[nameIdx + 1] : undefined) ||
+		(nameAltIdx !== -1 ? args[nameAltIdx + 1] : undefined)
+	const posArg =
+		args[1] && !args[1].startsWith("-") ? args[1] : undefined
 	const skipBuild = args.includes("--no-build")
 	const force = args.includes("--force")
-	const posArg = args[1] && !args[1].startsWith("-") ? args[1] : undefined
 	const follow = !args.includes("--no-follow")
 	return {
 		platform: providerFlag,
-		name: nameFlag || posArg,
+		name: name || posArg || nameFlag,
 		skipBuild,
 		force,
-		follow
+		follow,
 	}
 }
 
@@ -768,8 +763,11 @@ async function deployCommand(args: string[]) {
 	}
 
 	const name = args.find((a, i) => i > 1 && !a.startsWith("-"))
-	const platform =
-		args[args.indexOf("--provider") + 1] || args[args.indexOf("-p") + 1]
+	const pIdx = args.indexOf("--provider")
+	const pAlt = args.indexOf("-p")
+	const subPlatform =
+		(pIdx !== -1 ? args[pIdx + 1] : undefined) ||
+		(pAlt !== -1 ? args[pAlt + 1] : undefined)
 
 	switch (sub) {
 		case "sleep": {
@@ -778,7 +776,7 @@ async function deployCommand(args: string[]) {
 				process.exit(1)
 			}
 			const { runSleep } = await loadDeploy()
-			await runSleep(name, platform, projectRoot)
+			await runSleep(name, subPlatform, projectRoot)
 			break
 		}
 		case "wake": {
@@ -787,7 +785,7 @@ async function deployCommand(args: string[]) {
 				process.exit(1)
 			}
 			const { runWake } = await loadDeploy()
-			await runWake(name, platform, projectRoot)
+			await runWake(name, subPlatform, projectRoot)
 			break
 		}
 		case "status": {
@@ -796,7 +794,7 @@ async function deployCommand(args: string[]) {
 				process.exit(1)
 			}
 			const { runStatus } = await loadDeploy()
-			await runStatus(name, platform, projectRoot)
+			await runStatus(name, subPlatform, projectRoot)
 			break
 		}
 		case "logs": {
@@ -806,7 +804,7 @@ async function deployCommand(args: string[]) {
 			}
 			const follow = !args.includes("--no-follow")
 			const { runLogs } = await loadDeploy()
-			await runLogs(name, follow, platform, projectRoot)
+			await runLogs(name, follow, subPlatform, projectRoot)
 			break
 		}
 		case "teardown": {
@@ -815,7 +813,7 @@ async function deployCommand(args: string[]) {
 				process.exit(1)
 			}
 			const { runTeardown } = await loadDeploy()
-			await runTeardown(name, platform, projectRoot)
+			await runTeardown(name, subPlatform, projectRoot)
 			break
 		}
 		default:

--- a/packages/cli/src/deploy/deploy-provider.ts
+++ b/packages/cli/src/deploy/deploy-provider.ts
@@ -1,0 +1,81 @@
+// ============================================================================
+// DeployProvider Interface
+// ============================================================================
+
+export type InstanceStatus =
+	| "running"
+	| "sleeping"
+	| "stopped"
+	| "provisioning"
+	| "error"
+	| "unknown"
+
+export type ProviderName = "sprites" | "e2b" | "northflank" | "daytona"
+
+export interface ProvisionOpts {
+	/** Memory in MB (provider-specific defaults if omitted) */
+	memory?: number
+	/** vCPU count (provider-specific defaults if omitted) */
+	cpus?: number
+	/** Environment variables to set on the instance */
+	env?: Record<string, string>
+}
+
+export interface DeployProvider {
+	/** Unique provider identifier: "sprites" | "e2b" | "northflank" | "daytona" */
+	readonly name: ProviderName
+
+	/** Human-readable label for CLI prompts */
+	readonly label: string
+
+	/** Default instance name when user doesn't specify one */
+	defaultName(projectDir: string): string
+
+	/**
+	 * Verify prerequisites: CLI installed, authenticated, accessible.
+	 * Throws with a helpful message if requirements aren't met.
+	 */
+	authCheck(): Promise<void>
+
+	/**
+	 * Provision a new Firecracker microVM.
+	 * Returns an instance ID or name used for subsequent operations.
+	 */
+	provision(name: string, opts?: ProvisionOpts): Promise<string>
+
+	/**
+	 * Push the built agent bundle (from distDir) into the running VM.
+	 * Handles uploading, extracting, installing deps.
+	 */
+	deploy(instanceId: string, distDir: string): Promise<void>
+
+	/**
+	 * Return current lifecycle state of the instance.
+	 */
+	status(instanceId: string): Promise<InstanceStatus>
+
+	/**
+	 * Put the VM to sleep (pause, stop, or scale-to-zero depending on provider).
+	 */
+	sleep(instanceId: string): Promise<void>
+
+	/**
+	 * Wake the VM from sleep (resume, start, or trigger cold start).
+	 */
+	wake(instanceId: string): Promise<void>
+
+	/**
+	 * Stream logs from the agent process.
+	 */
+	logs(instanceId: string, follow?: boolean): Promise<void>
+
+	/**
+	 * Return the public-facing endpoint URL for the agent.
+	 */
+	endpoint(instanceId: string): Promise<string>
+
+	/**
+	 * Destroy the VM and all associated resources.
+	 */
+	teardown(instanceId: string): Promise<void>
+}

--- a/packages/cli/src/deploy/deploy.ts
+++ b/packages/cli/src/deploy/deploy.ts
@@ -1,0 +1,309 @@
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync
+} from "node:fs"
+import { resolve } from "node:path"
+import type { ProviderName } from "./deploy-provider"
+import { getProvider } from "./index"
+
+// ============================================================================
+// Unified Deploy Orchestration
+// ============================================================================
+
+export interface DeployOptions {
+	/** Platform/provider name (sprites, e2b, northflank, daytona) */
+	platform?: string
+	/** Instance name (VM name) */
+	name?: string
+	/** Skip build step */
+	skipBuild?: boolean
+	/** Force recreate instance even if it exists */
+	force?: boolean
+}
+
+export async function runDeploy(
+	options: DeployOptions,
+	projectRoot: string,
+	packageDir: string
+) {
+	// 1. Resolve platform
+	const platform = resolvePlatform(options.platform, projectRoot)
+
+	// 2. Load provider
+	const provider = await getProvider(platform as ProviderName)
+	console.log(`\n🚀 Deploying to ${provider.label}...`)
+
+	// 3. Auth check
+	try {
+		await provider.authCheck()
+	} catch (err: any) {
+		console.error(`\n❌ ${err.message}`)
+		process.exit(1)
+	}
+
+	// 4. Build
+	if (!options.skipBuild) {
+		await runBuild(projectRoot, packageDir)
+	}
+
+	// 5. Determine instance name
+	const distDir = resolve(projectRoot, "dist")
+	const instanceName = options.name || provider.defaultName(projectRoot)
+
+	// 6. Provision or reuse
+	console.log(`\n📋 Instance: ${instanceName}`)
+	const existingStatus = await provider.status(instanceName)
+
+	if (existingStatus === "running" && !options.force) {
+		console.log(`   ⚠️  Instance "${instanceName}" is already running.`)
+		const prompts = (await import("prompts")).default
+		const choice = await prompts({
+			type: "select",
+			name: "action",
+			message: "What do you want to do?",
+			choices: [
+				{ title: "Redeploy (overwrite artifacts)", value: "redeploy" },
+				{ title: "Force recreate VM", value: "force" },
+				{ title: "Cancel", value: "cancel" }
+			]
+		})
+		if (choice.action === "cancel") {
+			console.log("\n  Cancelled.\n")
+			process.exit(0)
+		}
+		if (choice.action === "force") {
+			await provider.teardown(instanceName)
+			await provider.provision(instanceName)
+		}
+		// redeploy: use existing instance, just push new artifacts
+	}
+
+	if (
+		existingStatus === "unknown" ||
+		existingStatus === "stopped" ||
+		options.force
+	) {
+		await provider.provision(instanceName)
+	}
+
+	// 7. Deploy artifacts
+	await provider.deploy(instanceName, distDir)
+
+	// 8. Print results
+	const endpoint = await provider.endpoint(instanceName)
+	console.log(`\n   Instance: ${instanceName}`)
+	console.log(`   URL: ${endpoint}`)
+	console.log(`   Health: ${endpoint}/health`)
+	console.log(`   Chat: ${endpoint}/api/chat`)
+	console.log("\n✅ Deployed!")
+}
+
+export async function runSleep(
+	name: string,
+	platform: string | undefined,
+	projectRoot: string
+) {
+	const provider = await getProvider(
+		resolvePlatform(platform, projectRoot) as ProviderName
+	)
+	await provider.authCheck()
+	await provider.sleep(name)
+}
+
+export async function runWake(
+	name: string,
+	platform: string | undefined,
+	projectRoot: string
+) {
+	const provider = await getProvider(
+		resolvePlatform(platform, projectRoot) as ProviderName
+	)
+	await provider.authCheck()
+	await provider.wake(name)
+}
+
+export async function runStatus(
+	name: string,
+	platform: string | undefined,
+	projectRoot: string
+) {
+	const provider = await getProvider(
+		resolvePlatform(platform, projectRoot) as ProviderName
+	)
+	await provider.authCheck()
+	const status = await provider.status(name)
+	const endpoint = await provider.endpoint(name)
+	console.log(`\n📋 Instance: ${name}`)
+	console.log(`   Status: ${status}`)
+	console.log(`   URL: ${endpoint}`)
+}
+
+export async function runLogs(
+	name: string,
+	follow: boolean,
+	platform: string | undefined,
+	projectRoot: string
+) {
+	const provider = await getProvider(
+		resolvePlatform(platform, projectRoot) as ProviderName
+	)
+	await provider.authCheck()
+	await provider.logs(name, follow)
+}
+
+export async function runTeardown(
+	name: string,
+	platform: string | undefined,
+	projectRoot: string
+) {
+	const provider = await getProvider(
+		resolvePlatform(platform, projectRoot) as ProviderName
+	)
+	await provider.authCheck()
+	await provider.teardown(name)
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function resolvePlatform(
+	platform?: string,
+	projectRoot?: string
+): ProviderName {
+	if (platform) return platform as ProviderName
+
+	// Check hybrid.config.ts
+	if (projectRoot) {
+		const configPath = resolve(projectRoot, "hybrid.config.ts")
+		if (existsSync(configPath)) {
+			const content = readFileSync(configPath, "utf-8")
+			const match = content.match(
+				/(?:platform|deployPlatform)\s*[=:]\s*["']([^"']+)["']/
+			)
+			if (match) return match[1] as ProviderName
+		}
+	}
+
+	// Default to sprites (only implemented provider right now)
+	return "sprites"
+}
+
+// ============================================================================
+// Build (extracted subset for deploy use)
+// ============================================================================
+
+async function runBuild(projectRoot: string, packageDir: string) {
+	const distDir = resolve(projectRoot, "dist")
+
+	console.log("\n🔧 Building agent...")
+
+	if (existsSync(distDir)) {
+		rmSync(distDir, { recursive: true, force: true })
+	}
+	mkdirSync(distDir, { recursive: true })
+	mkdirSync(resolve(distDir, "server"), { recursive: true })
+
+	console.log("📦 Copying agent runtime...")
+	const agentDistDir = resolve(packageDir, "dist")
+	const files = ["server/index.cjs"]
+	for (const file of files) {
+		const src = resolve(agentDistDir, file)
+		if (existsSync(src)) {
+			cpSync(src, resolve(distDir, file))
+		}
+	}
+
+	console.log("📋 Copying agent config...")
+	const configFiles = [
+		"SOUL.md",
+		"AGENTS.md",
+		"IDENTITY.md",
+		"TOOLS.md",
+		"BOOT.md",
+		"BOOTSTRAP.md",
+		"HEARTBEAT.md",
+		"USER.md"
+	]
+	for (const file of configFiles) {
+		const src = resolve(projectRoot, file)
+		if (existsSync(src)) {
+			cpSync(src, resolve(distDir, file))
+		}
+	}
+
+	// Copy credentials
+	const credsDir = resolve(projectRoot, "credentials")
+	if (existsSync(credsDir)) {
+		cpSync(credsDir, resolve(distDir, "credentials"), { recursive: true })
+	}
+
+	// package.json
+	const deployPkg = {
+		name: "hybrid",
+		version: "1.0.0",
+		type: "module",
+		dependencies: {
+			"@anthropic-ai/claude-agent-sdk": "^0.2.38",
+			"@hono/node-server": "^1.13.5",
+			ai: "^6.0.0",
+			"better-sqlite3": "^11.0.0",
+			dotenv: "^16.4.5",
+			hono: "^4.10.8",
+			"sql.js": "^1.11.0",
+			zod: "^4.0.0"
+		}
+	}
+	writeFileSync(
+		resolve(distDir, "package.json"),
+		JSON.stringify(deployPkg, null, 2)
+	)
+
+	// Generic Dockerfile
+	writeFileSync(
+		resolve(distDir, "Dockerfile"),
+		`FROM node:20-bookworm-slim
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY server/ ./server/
+COPY SOUL.md AGENTS.md IDENTITY.md TOOLS.md BOOT.md BOOTSTRAP.md HEARTBEAT.md USER.md ./
+COPY credentials/ ./credentials/ 2>/dev/null || true
+ENV AGENT_PORT=8454
+ENV NODE_ENV=production
+ENV DATA_ROOT=/app/data
+EXPOSE 8454
+USER node
+CMD ["node", "server/index.cjs"]
+`
+	)
+
+	// start.sh
+	writeFileSync(
+		resolve(distDir, "start.sh"),
+		`#!/bin/sh\nnode server/index.cjs\n`
+	)
+
+	// .hybrid-deploy.json manifest
+	writeFileSync(
+		resolve(distDir, ".hybrid-deploy.json"),
+		JSON.stringify(
+			{
+				version: 1,
+				provider: "firecracker",
+				startCommand: "node server/index.cjs",
+				port: 8454,
+				healthPath: "/health"
+			},
+			null,
+			2
+		)
+	)
+
+	console.log("\n✅ Build complete!")
+	console.log(`   Output: ${distDir}`)
+}

--- a/packages/cli/src/deploy/deploy.ts
+++ b/packages/cli/src/deploy/deploy.ts
@@ -280,7 +280,7 @@ COPY package.json ./
 RUN npm install --production
 COPY server/ ./server/
 COPY SOUL.md AGENTS.md IDENTITY.md TOOLS.md BOOT.md BOOTSTRAP.md HEARTBEAT.md USER.md ./
-COPY credentials/ ./credentials/ 2>/dev/null || true
+COPY credentials/ ./credentials/
 ENV AGENT_PORT=8454
 ENV NODE_ENV=production
 ENV DATA_ROOT=/app/data

--- a/packages/cli/src/deploy/deploy.ts
+++ b/packages/cli/src/deploy/deploy.ts
@@ -54,11 +54,19 @@ export async function runDeploy(
 	const distDir = resolve(projectRoot, "dist")
 	const instanceName = options.name || provider.defaultName(projectRoot)
 
-	// 6. Provision or reuse
+	// 6. Provision or reuse based on current status
 	console.log(`\n📋 Instance: ${instanceName}`)
 	const existingStatus = await provider.status(instanceName)
 
-	if (existingStatus === "running" && !options.force) {
+	if (options.force) {
+		if (existingStatus === "running" || existingStatus === "sleeping") {
+			await provider.teardown(instanceName)
+		}
+		await provider.provision(instanceName)
+	} else if (existingStatus === "sleeping") {
+		console.log(`   ☀️  Waking sleeping instance...`)
+		await provider.wake(instanceName)
+	} else if (existingStatus === "running") {
 		console.log(`   ⚠️  Instance "${instanceName}" is already running.`)
 		const prompts = (await import("prompts")).default
 		const choice = await prompts({
@@ -68,8 +76,8 @@ export async function runDeploy(
 			choices: [
 				{ title: "Redeploy (overwrite artifacts)", value: "redeploy" },
 				{ title: "Force recreate VM", value: "force" },
-				{ title: "Cancel", value: "cancel" }
-			]
+				{ title: "Cancel", value: "cancel" },
+			],
 		})
 		if (choice.action === "cancel") {
 			console.log("\n  Cancelled.\n")
@@ -80,17 +88,14 @@ export async function runDeploy(
 			await provider.provision(instanceName)
 		}
 		// redeploy: use existing instance, just push new artifacts
-	}
-
-	if (
-		existingStatus === "unknown" ||
-		existingStatus === "stopped" ||
-		options.force
-	) {
-		if (options.force && existingStatus === "running") {
-			await provider.teardown(instanceName)
-		}
+	} else if (existingStatus === "unknown" || existingStatus === "stopped") {
 		await provider.provision(instanceName)
+	} else if (existingStatus === "provisioning") {
+		console.error(`   ⏳ Instance still provisioning, try again shortly.`)
+		process.exit(1)
+	} else if (existingStatus === "error") {
+		console.error(`   ❌ Instance in error state. Run 'hybrid deploy teardown ${instanceName}' then retry.`)
+		process.exit(1)
 	}
 
 	// 7. Deploy artifacts

--- a/packages/cli/src/deploy/deploy.ts
+++ b/packages/cli/src/deploy/deploy.ts
@@ -87,6 +87,9 @@ export async function runDeploy(
 		existingStatus === "stopped" ||
 		options.force
 	) {
+		if (options.force && existingStatus === "running") {
+			await provider.teardown(instanceName)
+		}
 		await provider.provision(instanceName)
 	}
 

--- a/packages/cli/src/deploy/deploy.ts
+++ b/packages/cli/src/deploy/deploy.ts
@@ -276,7 +276,8 @@ async function runBuild(projectRoot: string, packageDir: string) {
 		existsSync(resolve(distDir, f)),
 	)
 	const hasCredentials = existsSync(resolve(distDir, "credentials"))
-	const configCopy = present.join(" ")
+	const configCopy =
+		present.length > 0 ? `COPY ${present.join(" ")} ./` : ""
 	const credCopy = hasCredentials
 		? "COPY credentials/ ./credentials/"
 		: "COPY .hybrid-deploy.json ./"

--- a/packages/cli/src/deploy/deploy.ts
+++ b/packages/cli/src/deploy/deploy.ts
@@ -271,7 +271,16 @@ async function runBuild(projectRoot: string, packageDir: string) {
 		JSON.stringify(deployPkg, null, 2)
 	)
 
-	// Generic Dockerfile
+	// Generate Dockerfile — only COPY files that exist in dist
+	const present = configFiles.filter((f) =>
+		existsSync(resolve(distDir, f)),
+	)
+	const hasCredentials = existsSync(resolve(distDir, "credentials"))
+	const configCopy = present.join(" ")
+	const credCopy = hasCredentials
+		? "COPY credentials/ ./credentials/"
+		: "COPY .hybrid-deploy.json ./"
+
 	writeFileSync(
 		resolve(distDir, "Dockerfile"),
 		`FROM node:20-bookworm-slim
@@ -279,8 +288,8 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --production
 COPY server/ ./server/
-COPY SOUL.md AGENTS.md IDENTITY.md TOOLS.md BOOT.md BOOTSTRAP.md HEARTBEAT.md USER.md ./
-COPY credentials/ ./credentials/
+COPY ${configCopy} ./
+${credCopy}
 ENV AGENT_PORT=8454
 ENV NODE_ENV=production
 ENV DATA_ROOT=/app/data

--- a/packages/cli/src/deploy/index.ts
+++ b/packages/cli/src/deploy/index.ts
@@ -6,15 +6,17 @@ const providers: Record<ProviderName, ProviderEntry | undefined> = {
 	sprites: () =>
 		import("./providers/sprite.provider").then((m) => m.spriteProvider),
 	e2b: () => import("./providers/e2b.provider").then((m) => m.e2bProvider),
-	northflank: undefined,
-	daytona: undefined
+	northflank: () =>
+		import("./providers/northflank.provider").then((m) => m.northflankProvider),
+	daytona: () =>
+		import("./providers/daytona.provider").then((m) => m.daytonaProvider)
 }
 
 export async function getProvider(name: ProviderName): Promise<DeployProvider> {
 	const entry = providers[name]
 	if (!entry) {
 		throw new Error(
-			`Provider "${name}" is not yet implemented.\nAvailable providers: sprites, e2b`
+			`Provider "${name}" is not yet implemented.\nAvailable providers: sprites, e2b, northflank, daytona`
 		)
 	}
 	if (typeof entry === "function") {

--- a/packages/cli/src/deploy/index.ts
+++ b/packages/cli/src/deploy/index.ts
@@ -1,0 +1,30 @@
+import type { DeployProvider, ProviderName } from "./deploy-provider"
+
+type ProviderEntry = DeployProvider | (() => Promise<DeployProvider>)
+
+const providers: Record<ProviderName, ProviderEntry | undefined> = {
+	sprites: () =>
+		import("./providers/sprite.provider").then((m) => m.spriteProvider),
+	e2b: undefined,
+	northflank: undefined,
+	daytona: undefined
+}
+
+export async function getProvider(name: ProviderName): Promise<DeployProvider> {
+	const entry = providers[name]
+	if (!entry) {
+		throw new Error(
+			`Provider "${name}" is not yet implemented.\nAvailable provider: sprites`
+		)
+	}
+	if (typeof entry === "function") {
+		return entry()
+	}
+	return entry as DeployProvider
+}
+
+export function getAvailableProviders(): ProviderName[] {
+	return (Object.keys(providers) as ProviderName[]).filter(
+		(n) => providers[n] != null
+	)
+}

--- a/packages/cli/src/deploy/index.ts
+++ b/packages/cli/src/deploy/index.ts
@@ -5,7 +5,7 @@ type ProviderEntry = DeployProvider | (() => Promise<DeployProvider>)
 const providers: Record<ProviderName, ProviderEntry | undefined> = {
 	sprites: () =>
 		import("./providers/sprite.provider").then((m) => m.spriteProvider),
-	e2b: undefined,
+	e2b: () => import("./providers/e2b.provider").then((m) => m.e2bProvider),
 	northflank: undefined,
 	daytona: undefined
 }
@@ -14,7 +14,7 @@ export async function getProvider(name: ProviderName): Promise<DeployProvider> {
 	const entry = providers[name]
 	if (!entry) {
 		throw new Error(
-			`Provider "${name}" is not yet implemented.\nAvailable provider: sprites`
+			`Provider "${name}" is not yet implemented.\nAvailable providers: sprites, e2b`
 		)
 	}
 	if (typeof entry === "function") {

--- a/packages/cli/src/deploy/providers/daytona.provider.ts
+++ b/packages/cli/src/deploy/providers/daytona.provider.ts
@@ -115,18 +115,30 @@ export const daytonaProvider: DeployProvider = {
 				`${instanceId}:/workspace/app/hybrid-deploy.tar.gz`
 			])
 		} catch {
-			// Fallback: use daytona code --command with base64 encoding
+			// Fallback: pipe tarball to daytona code via stdin
 			const { readFileSync } = await import("node:fs")
+			const { spawn } = await import("node:child_process")
 			const tarContent = readFileSync(tarPath)
-			const base64 = tarContent.toString("base64")
 
-			// Write in chunks if content is large
-			runDaytonaInherit([
-				"code",
-				instanceId,
-				"--command",
-				`echo "${base64}" | base64 -d > /workspace/app/hybrid-deploy.tar.gz`
-			])
+			// Use shell pipe to avoid MAX_ARG_STRLEN limit
+			const shell = spawn(
+				"sh",
+				[
+					"-c",
+					`cat | base64 -d > /workspace/app/hybrid-deploy.tar.gz`
+				],
+				{ stdio: ["pipe", "pipe", "pipe"] }
+			)
+
+			shell.stdin.write(tarContent.toString("base64"))
+			shell.stdin.end()
+
+			await new Promise<void>((resolve, reject) => {
+				shell.on("exit", (code) => {
+					if (code === 0) resolve()
+					else reject(new Error(`base64 decode failed with code ${code}`))
+				})
+			})
 		}
 
 		// Extract and install deps

--- a/packages/cli/src/deploy/providers/daytona.provider.ts
+++ b/packages/cli/src/deploy/providers/daytona.provider.ts
@@ -115,30 +115,10 @@ export const daytonaProvider: DeployProvider = {
 				`${instanceId}:/workspace/app/hybrid-deploy.tar.gz`
 			])
 		} catch {
-			// Fallback: pipe tarball to daytona code via stdin
-			const { readFileSync } = await import("node:fs")
-			const { spawn } = await import("node:child_process")
-			const tarContent = readFileSync(tarPath)
-
-			// Use shell pipe to avoid MAX_ARG_STRLEN limit
-			const shell = spawn(
-				"sh",
-				[
-					"-c",
-					`cat | base64 -d > /workspace/app/hybrid-deploy.tar.gz`
-				],
-				{ stdio: ["pipe", "pipe", "pipe"] }
+			throw new Error(
+				`daytona cp failed for instance ${instanceId}.\n` +
+					`Ensure the Daytona CLI supports file copy: daytona cp ${tarPath} ${instanceId}:/workspace/app/hybrid-deploy.tar.gz`
 			)
-
-			shell.stdin.write(tarContent.toString("base64"))
-			shell.stdin.end()
-
-			await new Promise<void>((resolve, reject) => {
-				shell.on("exit", (code) => {
-					if (code === 0) resolve()
-					else reject(new Error(`base64 decode failed with code ${code}`))
-				})
-			})
 		}
 
 		// Extract and install deps

--- a/packages/cli/src/deploy/providers/daytona.provider.ts
+++ b/packages/cli/src/deploy/providers/daytona.provider.ts
@@ -1,0 +1,255 @@
+import { execFileSync, spawn } from "node:child_process"
+import { existsSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
+import type {
+	DeployProvider,
+	InstanceStatus,
+	ProvisionOpts
+} from "../deploy-provider"
+
+// ============================================================================
+// Daytona Provider
+//
+// Uses the `daytona` CLI for workspace management.
+// Daytona creates Firecracker-based dev workspaces on local or cloud providers.
+//
+// Sleep/wake: `daytona stop` / `daytona start` — full stop/start cycle (~30s wake)
+// This is the slowest wake time of all providers.
+// ============================================================================
+
+const CLI = "daytona"
+
+function runDaytona(args: string[]): string {
+	return execFileSync(CLI, args, {
+		encoding: "utf-8",
+		stdio: ["pipe", "pipe", "pipe"]
+	})
+}
+
+function runDaytonaInherit(args: string[]): void {
+	execFileSync(CLI, args, { stdio: "inherit" })
+}
+
+export const daytonaProvider: DeployProvider = {
+	name: "daytona",
+	label: "Daytona.io (Firecracker / Dev Workspace)",
+
+	defaultName(projectDir: string): string {
+		return basename(projectDir)
+			.toLowerCase()
+			.replace(/[^a-z0-9-]/g, "-")
+			.replace(/-+/g, "-")
+			.replace(/^-+|-+$/g, "")
+			.slice(0, 40)
+	},
+
+	async authCheck(): Promise<void> {
+		try {
+			runDaytona(["info"])
+		} catch (err: any) {
+			if (err.code === "ENOENT") {
+				throw new Error(
+					"`daytona` CLI not found.\n    " +
+						"Install: https://www.daytona.io/docs/getting-started/installation/\n    " +
+						"Or: curl -NF https://download.daytona.io/daytona/install.sh | sh"
+				)
+			}
+			throw new Error(`Daytona CLI error: ${err.stderr || err.message}`)
+		}
+	},
+
+	async provision(name: string, opts?: ProvisionOpts): Promise<string> {
+		// Check if workspace already exists
+		try {
+			const existing = runDaytona(["list"])
+			// Parse daytona list output to find matching workspace
+			const lines = existing.split("\n")
+			const found = lines.find((l) => l.includes(name))
+			if (found) {
+				console.log(`   ⚠️  Workspace already exists: ${name}`)
+				return name
+			}
+		} catch {
+			// No workspaces listed, create new
+		}
+
+		console.log(`\n📦 Creating Daytona workspace: ${name}`)
+
+		// Create workspace with Node.js image
+		const image = opts?.memory ? "node:20" : "node:20"
+		const args = ["create", "--name", name, "--image", image]
+
+		// Add provider flag if specified
+		const provider = process.env.DAYTONA_PROVIDER
+		if (provider) {
+			args.push("--provider", provider)
+		}
+
+		runDaytonaInherit(args)
+		console.log("   ✓ Workspace created")
+		return name
+	},
+
+	async deploy(instanceId: string, distDir: string): Promise<void> {
+		console.log("\n📤 Uploading build artifacts...")
+
+		const tarPath = join(tmpdir(), `hybrid-daytona-${Date.now()}.tar.gz`)
+		execFileSync("tar", ["-czf", tarPath, "-C", distDir, "."], {
+			stdio: "pipe"
+		})
+
+		// Create app directory
+		runDaytonaInherit([
+			"code",
+			instanceId,
+			"--command",
+			"mkdir -p /workspace/app"
+		])
+
+		// Upload tarball using daytona cp (if available) or code command
+		try {
+			runDaytonaInherit([
+				"cp",
+				tarPath,
+				`${instanceId}:/workspace/app/hybrid-deploy.tar.gz`
+			])
+		} catch {
+			// Fallback: use daytona code --command with base64 encoding
+			const { readFileSync } = await import("node:fs")
+			const tarContent = readFileSync(tarPath)
+			const base64 = tarContent.toString("base64")
+
+			// Write in chunks if content is large
+			runDaytonaInherit([
+				"code",
+				instanceId,
+				"--command",
+				`echo "${base64}" | base64 -d > /workspace/app/hybrid-deploy.tar.gz`
+			])
+		}
+
+		// Extract and install deps
+		runDaytonaInherit([
+			"code",
+			instanceId,
+			"--command",
+			"cd /workspace/app && tar -xzf hybrid-deploy.tar.gz && npm install --production"
+		])
+
+		// Clean up tarball
+		if (existsSync(tarPath)) {
+			try {
+				unlinkSync(tarPath)
+			} catch {}
+		}
+
+		// Start the agent
+		console.log("\n🔧 Starting agent...")
+		runDaytonaInherit([
+			"code",
+			instanceId,
+			"--command",
+			"cd /workspace/app && export NODE_ENV=production AGENT_PORT=8454 && nohup node server/index.cjs > /workspace/app/agent.log 2>&1 &"
+		])
+
+		// Wait for health check
+		console.log("\n⏳ Waiting for agent to start...")
+		let ready = false
+		for (let i = 0; i < 15; i++) {
+			try {
+				const result = runDaytona([
+					"code",
+					instanceId,
+					"--command",
+					"curl -sf http://localhost:8454/health || echo not-ready"
+				])
+				if (result && !result.includes("not-ready")) {
+					ready = true
+					break
+				}
+			} catch {
+				// Agent not ready yet
+			}
+			await new Promise((r) => setTimeout(r, 2000))
+		}
+
+		if (!ready) {
+			console.log("   ⚠️  Agent health check timed out")
+		} else {
+			console.log("   ✓ Agent running")
+		}
+	},
+
+	async status(instanceId: string): Promise<InstanceStatus> {
+		try {
+			const list = runDaytona(["list"])
+			const lines = list.split("\n")
+			const found = lines.find((l) => l.includes(instanceId))
+			if (!found) return "stopped"
+
+			const lower = found.toLowerCase()
+			if (lower.includes("started") || lower.includes("running")) {
+				return "running"
+			}
+			if (lower.includes("stopped")) {
+				return "stopped"
+			}
+			return "unknown"
+		} catch {
+			return "unknown"
+		}
+	},
+
+	async sleep(instanceId: string): Promise<void> {
+		console.log(`\n💤 Stopping Daytona workspace: ${instanceId}`)
+		try {
+			runDaytonaInherit(["stop", instanceId])
+			console.log("   ✓ Workspace stopped")
+		} catch (err: any) {
+			throw new Error(`Failed to stop workspace: ${err.stderr || err.message}`)
+		}
+	},
+
+	async wake(instanceId: string): Promise<void> {
+		console.log(`\n☀️  Starting Daytona workspace: ${instanceId}`)
+		try {
+			runDaytonaInherit(["start", instanceId])
+			console.log("   ✓ Workspace starting (~30s)")
+		} catch (err: any) {
+			throw new Error(`Failed to start workspace: ${err.stderr || err.message}`)
+		}
+	},
+
+	async logs(instanceId: string, follow = true): Promise<void> {
+		const args = follow
+			? ["code", instanceId, "--command", "tail -f /workspace/app/agent.log"]
+			: ["code", instanceId, "--command", "cat /workspace/app/agent.log"]
+
+		const child = spawn(CLI, args, { stdio: "inherit" })
+		return new Promise((resolve, reject) => {
+			child.on("exit", (code) => {
+				if (code === 0) resolve()
+				else reject(new Error(`daytona exited with code ${code}`))
+			})
+		})
+	},
+
+	async endpoint(instanceId: string): Promise<string> {
+		// Daytona workspaces don't have public endpoints by default
+		// Would need to configure port forwarding
+		return `daytona://${instanceId}`
+	},
+
+	async teardown(instanceId: string): Promise<void> {
+		console.log(`\n🗑️  Destroying Daytona workspace: ${instanceId}`)
+		try {
+			runDaytonaInherit(["remove", instanceId])
+			console.log("   ✓ Workspace destroyed")
+		} catch (err: any) {
+			throw new Error(
+				`Failed to destroy workspace: ${err.stderr || err.message}`
+			)
+		}
+	}
+}

--- a/packages/cli/src/deploy/providers/e2b.provider.ts
+++ b/packages/cli/src/deploy/providers/e2b.provider.ts
@@ -1,0 +1,353 @@
+import { execFileSync } from "node:child_process"
+import { existsSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
+import type {
+	DeployProvider,
+	InstanceStatus,
+	ProvisionOpts
+} from "../deploy-provider"
+
+// ============================================================================
+// E2B.dev Provider
+//
+// Uses the `e2b` SDK npm package for sandbox management.
+// Requires E2B_API_KEY environment variable.
+//
+// Sleep/wake: Sandbox.pause() freezes state to persistent disk.
+//             Sandbox.resume(sandboxId) restores to exact state.
+// ============================================================================
+
+const DEFAULT_TEMPLATE = "hybrid" // Custom template with agent pre-installed
+
+async function importSDK() {
+	try {
+		// @ts-expect-error e2b is an optional peer dependency
+		const { Sandbox } = await import("e2b")
+		return Sandbox
+	} catch {
+		throw new Error(`e2b not installed.\nInstall with: npm install e2b`)
+	}
+}
+
+function getAPIKey(): string {
+	const key = process.env.E2B_API_KEY
+	if (!key) {
+		throw new Error(
+			"E2B_API_KEY not set.\nGet your key: https://e2b.dev/dashboard?tab=keys\nSet with: export E2B_API_KEY=e2b_xxx"
+		)
+	}
+	return key
+}
+
+// Map of active sandbox instances (so we don't lose references)
+const sandboxes = new Map<string, any>()
+
+export const e2bProvider: DeployProvider = {
+	name: "e2b",
+	label: "E2B.dev (Firecracker)",
+
+	defaultName(projectDir: string): string {
+		return basename(projectDir)
+			.toLowerCase()
+			.replace(/[^a-z0-9-]/g, "-")
+			.replace(/-+/g, "-")
+			.replace(/^-+|-+$/g, "")
+			.slice(0, 40)
+	},
+
+	async authCheck(): Promise<void> {
+		// Check API key
+		getAPIKey()
+
+		// Check SDK installed
+		try {
+			await importSDK()
+		} catch (err: any) {
+			throw new Error(err.message)
+		}
+
+		// Try listing sandboxes to verify auth works
+		const Sandbox = await importSDK()
+		try {
+			await Sandbox.list()
+		} catch (err: any) {
+			if (
+				err.message?.includes("401") ||
+				err.message?.includes("unauthorized")
+			) {
+				throw new Error(
+					"E2B API key is invalid.\nGet your key: https://e2b.dev/dashboard?tab=keys"
+				)
+			}
+			throw new Error(`E2B connection failed: ${err.message}`)
+		}
+	},
+
+	async provision(name: string, _opts?: ProvisionOpts): Promise<string> {
+		const Sandbox = await importSDK()
+		const apiKey = getAPIKey()
+
+		console.log(`\n📦 Creating E2B sandbox: ${name}`)
+
+		// Try to resume an existing paused sandbox first
+		try {
+			// Check if there's a paused sandbox with a matching metadata label
+			const list = await Sandbox.list({ limit: 50 })
+			let result: any = null
+			for (const s of list) {
+				const meta = s.metadata as Record<string, string> | undefined
+				if (meta?.["hybrid-name"] === name) {
+					result = s
+					break
+				}
+				// Fallback: match by sandbox ID suffix
+				if (s.sandboxId === name || s.sandboxId?.startsWith(name)) {
+					result = s
+					break
+				}
+			}
+
+			if (result) {
+				const sandbox = await Sandbox.resume({
+					sandboxId: result.sandboxId,
+					apiKey
+				})
+				sandboxes.set(name, sandbox)
+				console.log(`   ✓ Resumed existing sandbox: ${result.sandboxId}`)
+				return result.sandboxId
+			}
+		} catch {
+			// No existing sandbox, create new
+		}
+
+		// Create new sandbox
+		const sandbox = await Sandbox.create({
+			template: DEFAULT_TEMPLATE,
+			metadata: { "hybrid-name": name },
+			apiKey
+		})
+
+		sandboxes.set(name, sandbox)
+		console.log(`   ✓ Sandbox created: ${sandbox.sandboxId}`)
+		return sandbox.sandboxId
+	},
+
+	async deploy(instanceId: string, distDir: string): Promise<void> {
+		const sandbox = sandboxes.get(instanceId)
+		if (!sandbox) {
+			throw new Error(
+				`Sandbox ${instanceId} not found in active sessions.\nRun 'hybrid deploy' again to reconnect.`
+			)
+		}
+
+		console.log("\n📤 Uploading build artifacts...")
+
+		// Create tarball of dist
+		const tarPath = join(tmpdir(), `hybrid-e2b-deploy-${Date.now()}.tar.gz`)
+		execFileSync("tar", ["-czf", tarPath, "-C", distDir, "."], {
+			stdio: "pipe"
+		})
+
+		// Upload tarball to sandbox
+		try {
+			const fs = await import("node:fs/promises")
+			const tarBuffer = await fs.readFile(tarPath)
+			await sandbox.files.write("/tmp/hybrid-deploy.tar.gz", tarBuffer, {
+				onProgress: (p: number) => {
+					if (p === 100) console.log("   ✓ Upload complete")
+				}
+			})
+		} catch (err: any) {
+			throw new Error(`Upload failed: ${err.message}`)
+		} finally {
+			if (existsSync(tarPath)) {
+				try {
+					unlinkSync(tarPath)
+				} catch {}
+			}
+		}
+
+		// Extract and install deps
+		console.log("\n📦 Extracting and installing dependencies...")
+		const result = await sandbox.commands.run(
+			"cd /home/user && mkdir -p app && tar -xzf /tmp/hybrid-deploy.tar.gz -C app && cd app && npm install --production 2>&1",
+			{ timeout: 120000 }
+		)
+
+		if (result.stderr) {
+			console.log(`   ⚠️  ${result.stderr.slice(0, 200)}`)
+		}
+
+		if (result.exitCode !== 0) {
+			throw new Error(
+				`Dependency installation failed (exit ${result.exitCode})`
+			)
+		}
+
+		// Start the agent
+		console.log("\n🔧 Starting agent...")
+		await sandbox.commands.run(
+			"cd /home/user/app && export NODE_ENV=production AGENT_PORT=8454 && nohup node server/index.cjs > /tmp/agent.log 2>&1 & echo $! > /tmp/agent.pid",
+			{ timeout: 10000 }
+		)
+
+		// Wait for agent health check
+		console.log("\n⏳ Waiting for agent to start...")
+		let ready = false
+		for (let i = 0; i < 15; i++) {
+			try {
+				const health = await sandbox.commands.run(
+					"curl -sf http://localhost:8454/health || echo 'not ready'"
+				)
+				if (health.stdout && !health.stdout.includes("not ready")) {
+					ready = true
+					break
+				}
+			} catch {
+				// Agent not ready yet
+			}
+			await new Promise((r) => setTimeout(r, 2000))
+		}
+
+		if (!ready) {
+			console.log("   ⚠️  Agent health check timed out (may still be starting)")
+		} else {
+			console.log("   ✓ Agent running")
+		}
+	},
+
+	async status(instanceId: string): Promise<InstanceStatus> {
+		// Check if we have the sandbox cached
+		const cached = sandboxes.get(instanceId)
+		if (cached) {
+			return "running"
+		}
+
+		// Query E2B for sandbox state
+		try {
+			const Sandbox = await importSDK()
+			const list = await Sandbox.list({ limit: 50 })
+			const found = list.find(
+				(s: any) =>
+					s.sandboxId === instanceId || s.sandboxId?.startsWith(instanceId)
+			)
+			if (!found) {
+				return "stopped"
+			}
+			if (found.status === "paused") {
+				return "sleeping"
+			}
+			return "running"
+		} catch {
+			return "unknown"
+		}
+	},
+
+	async sleep(instanceId: string): Promise<void> {
+		const sandbox = sandboxes.get(instanceId)
+		if (!sandbox) {
+			throw new Error(
+				`Sandbox ${instanceId} not found in active sessions.\nCannot pause a sandbox that isn't connected.`
+			)
+		}
+
+		console.log(`\n💤 Pausing E2B sandbox: ${instanceId}`)
+		await sandbox.pause()
+		sandboxes.delete(instanceId)
+		console.log("   ✓ Sandbox paused (state preserved on disk)")
+	},
+
+	async wake(instanceId: string): Promise<void> {
+		const Sandbox = await importSDK()
+		const apiKey = getAPIKey()
+
+		console.log(`\n☀️  Resuming E2B sandbox: ${instanceId}`)
+		try {
+			const sandbox = await Sandbox.resume({ sandboxId: instanceId, apiKey })
+			sandboxes.set(instanceId, sandbox)
+			console.log("   ✓ Sandbox resumed")
+		} catch (err: any) {
+			throw new Error(
+				`Failed to resume sandbox: ${err.message}\nThe sandbox may have expired (E2B sandboxes have a maximum lifetime).`
+			)
+		}
+	},
+
+	async logs(instanceId: string, follow = true): Promise<void> {
+		const sandbox = sandboxes.get(instanceId)
+		if (!sandbox) {
+			throw new Error(
+				`Sandbox ${instanceId} not found. Wake it first with: hybrid deploy wake ${instanceId}`
+			)
+		}
+
+		if (follow) {
+			// Tail logs by polling
+			let offset = 0
+			while (true) {
+				try {
+					const result = await sandbox.commands.run(
+						`cat /tmp/agent.log 2>/dev/null || echo "No logs yet"`
+					)
+					const output = result.stdout || ""
+					if (output.length > offset) {
+						process.stdout.write(output.slice(offset))
+						offset = output.length
+					}
+					await new Promise((r) => setTimeout(r, 2000))
+				} catch {
+					await new Promise((r) => setTimeout(r, 2000))
+				}
+			}
+		} else {
+			const result = await sandbox.commands.run(
+				"cat /tmp/agent.log 2>/dev/null || echo 'No logs yet'"
+			)
+			console.log(result.stdout || "No logs yet")
+		}
+	},
+
+	async endpoint(instanceId: string): Promise<string> {
+		const sandbox = sandboxes.get(instanceId)
+		if (!sandbox) {
+			// E2B provides a predictable URL format
+			return `https://${instanceId}-8454.e2b.dev`
+		}
+
+		// Get the actual host URL from the sandbox
+		try {
+			const host = await sandbox.getHost(8454)
+			return `https://${host}`
+		} catch {
+			return `https://${instanceId}-8454.e2b.dev`
+		}
+	},
+
+	async teardown(instanceId: string): Promise<void> {
+		const Sandbox = await importSDK()
+
+		console.log(`\n🗑️  Destroying E2B sandbox: ${instanceId}`)
+		try {
+			// Kill the sandbox if we have a reference
+			const cached = sandboxes.get(instanceId)
+			if (cached) {
+				await cached.kill()
+			} else {
+				// Find by ID and kill
+				const list = await Sandbox.list({ limit: 50 })
+				const found = list.find(
+					(s: any) =>
+						s.sandboxId === instanceId || s.sandboxId?.startsWith(instanceId)
+				)
+				if (found) {
+					await found.kill()
+				}
+			}
+			sandboxes.delete(instanceId)
+			console.log("   ✓ Sandbox destroyed")
+		} catch (err: any) {
+			throw new Error(`Failed to destroy sandbox: ${err.message}`)
+		}
+	}
+}

--- a/packages/cli/src/deploy/providers/e2b.provider.ts
+++ b/packages/cli/src/deploy/providers/e2b.provider.ts
@@ -1,32 +1,35 @@
-import { execFileSync } from "node:child_process"
-import { existsSync, unlinkSync } from "node:fs"
+import { execFileSync, spawn } from "node:child_process"
+import { existsSync, unlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
 import type {
 	DeployProvider,
 	InstanceStatus,
-	ProvisionOpts
+	ProvisionOpts,
 } from "../deploy-provider"
 
 // ============================================================================
 // E2B.dev Provider
 //
-// Uses the `e2b` SDK npm package for sandbox management.
+// Uses the `e2b` npm package for sandbox management.
 // Requires E2B_API_KEY environment variable.
 //
-// Sleep/wake: Sandbox.pause() freezes state to persistent disk.
-//             Sandbox.resume(sandboxId) restores to exact state.
+// Sleep/wake: sandbox.pause() freezes state.
+//             Sandbox.connect(sandboxId) resumes (auto-resumes if paused).
 // ============================================================================
 
-const DEFAULT_TEMPLATE = "hybrid" // Custom template with agent pre-installed
+const DEFAULT_TEMPLATE = "base"
 
-async function importSDK() {
+type SandboxInstance = any // eslint-disable-line @typescript-eslint/no-explicit-any
+
+async function getSDK() {
 	try {
-		// @ts-expect-error e2b is an optional peer dependency
 		const { Sandbox } = await import("e2b")
 		return Sandbox
 	} catch {
-		throw new Error(`e2b not installed.\nInstall with: npm install e2b`)
+		throw new Error(
+			"e2b not installed.\nInstall with: npm install e2b",
+		)
 	}
 }
 
@@ -34,14 +37,13 @@ function getAPIKey(): string {
 	const key = process.env.E2B_API_KEY
 	if (!key) {
 		throw new Error(
-			"E2B_API_KEY not set.\nGet your key: https://e2b.dev/dashboard?tab=keys\nSet with: export E2B_API_KEY=e2b_xxx"
+			"E2B_API_KEY not set.\nGet your key: https://e2b.dev/dashboard?tab=keys\nSet with: export E2B_API_KEY=e2b_xxx",
 		)
 	}
 	return key
 }
 
-// Map of active sandbox instances (so we don't lose references)
-const sandboxes = new Map<string, any>()
+const sandboxes = new Map<string, SandboxInstance>()
 
 export const e2bProvider: DeployProvider = {
 	name: "e2b",
@@ -57,75 +59,70 @@ export const e2bProvider: DeployProvider = {
 	},
 
 	async authCheck(): Promise<void> {
-		// Check API key
 		getAPIKey()
-
-		// Check SDK installed
+		const Sandbox = await getSDK()
 		try {
-			await importSDK()
-		} catch (err: any) {
-			throw new Error(err.message)
-		}
-
-		// Try listing sandboxes to verify auth works
-		const Sandbox = await importSDK()
-		try {
-			await Sandbox.list()
-		} catch (err: any) {
-			if (
-				err.message?.includes("401") ||
-				err.message?.includes("unauthorized")
-			) {
+			// Try listing — Sandbox.list() returns a paginator in e2b v2
+			const paginator = Sandbox.list()
+			await paginator.nextItems()
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err)
+			if (msg.includes("401") || msg.includes("unauthorized")) {
 				throw new Error(
-					"E2B API key is invalid.\nGet your key: https://e2b.dev/dashboard?tab=keys"
+					"E2B API key is invalid.\nGet your key: https://e2b.dev/dashboard?tab=keys",
 				)
 			}
-			throw new Error(`E2B connection failed: ${err.message}`)
+			throw new Error(`E2B connection failed: ${msg}`)
 		}
 	},
 
 	async provision(name: string, _opts?: ProvisionOpts): Promise<string> {
-		const Sandbox = await importSDK()
-		const apiKey = getAPIKey()
+		const Sandbox = await getSDK()
 
 		console.log(`\n📦 Creating E2B sandbox: ${name}`)
 
 		// Try to resume an existing paused sandbox first
 		try {
-			// Check if there's a paused sandbox with a matching metadata label
-			const list = await Sandbox.list({ limit: 50 })
-			let result: any = null
-			for (const s of list) {
-				const meta = s.metadata as Record<string, string> | undefined
-				if (meta?.["hybrid-name"] === name) {
-					result = s
-					break
+			const paginator = Sandbox.list()
+			let found: any = null // eslint-disable-line @typescript-eslint/no-explicit-any
+			while (paginator.hasNext) {
+				const items = await paginator.nextItems()
+				for (const s of items) {
+					const info = s as any
+					const meta = info.metadata as
+						| Record<string, string>
+						| undefined
+					if (meta?.["hybrid-name"] === name) {
+						found = info
+						break
+					}
+					if (
+						info.sandboxId === name ||
+						info.sandboxId?.startsWith(name)
+					) {
+						found = info
+						break
+					}
 				}
-				// Fallback: match by sandbox ID suffix
-				if (s.sandboxId === name || s.sandboxId?.startsWith(name)) {
-					result = s
-					break
-				}
+				if (found) break
 			}
 
-			if (result) {
-				const sandbox = await Sandbox.resume({
-					sandboxId: result.sandboxId,
-					apiKey
-				})
+			if (found) {
+				// connect() auto-resumes if paused
+				const sandbox = await Sandbox.connect(found.sandboxId)
 				sandboxes.set(name, sandbox)
-				console.log(`   ✓ Resumed existing sandbox: ${result.sandboxId}`)
-				return result.sandboxId
+				console.log(
+					`   ✓ Resumed existing sandbox: ${found.sandboxId}`,
+				)
+				return found.sandboxId
 			}
 		} catch {
 			// No existing sandbox, create new
 		}
 
-		// Create new sandbox
-		const sandbox = await Sandbox.create({
-			template: DEFAULT_TEMPLATE,
+		// Create new sandbox — template is first positional arg in e2b v2
+		const sandbox = await Sandbox.create(DEFAULT_TEMPLATE, {
 			metadata: { "hybrid-name": name },
-			apiKey
 		})
 
 		sandboxes.set(name, sandbox)
@@ -137,29 +134,31 @@ export const e2bProvider: DeployProvider = {
 		const sandbox = sandboxes.get(instanceId)
 		if (!sandbox) {
 			throw new Error(
-				`Sandbox ${instanceId} not found in active sessions.\nRun 'hybrid deploy' again to reconnect.`
+				`Sandbox ${instanceId} not found in active sessions.\nRun 'hybrid deploy' again to reconnect.`,
 			)
 		}
 
 		console.log("\n📤 Uploading build artifacts...")
 
-		// Create tarball of dist
-		const tarPath = join(tmpdir(), `hybrid-e2b-deploy-${Date.now()}.tar.gz`)
+		const tarPath = join(
+			tmpdir(),
+			`hybrid-e2b-deploy-${Date.now()}.tar.gz`,
+		)
 		execFileSync("tar", ["-czf", tarPath, "-C", distDir, "."], {
-			stdio: "pipe"
+			stdio: "pipe",
 		})
 
-		// Upload tarball to sandbox
 		try {
 			const fs = await import("node:fs/promises")
 			const tarBuffer = await fs.readFile(tarPath)
 			await sandbox.files.write("/tmp/hybrid-deploy.tar.gz", tarBuffer, {
-				onProgress: (p: number) => {
-					if (p === 100) console.log("   ✓ Upload complete")
-				}
+				onProgress: () => {},
 			})
-		} catch (err: any) {
-			throw new Error(`Upload failed: ${err.message}`)
+			console.log("   ✓ Upload complete")
+		} catch (err: unknown) {
+			throw new Error(
+				`Upload failed: ${err instanceof Error ? err.message : String(err)}`,
+			)
 		} finally {
 			if (existsSync(tarPath)) {
 				try {
@@ -172,7 +171,7 @@ export const e2bProvider: DeployProvider = {
 		console.log("\n📦 Extracting and installing dependencies...")
 		const result = await sandbox.commands.run(
 			"cd /home/user && mkdir -p app && tar -xzf /tmp/hybrid-deploy.tar.gz -C app && cd app && npm install --production 2>&1",
-			{ timeout: 120000 }
+			{ timeout: 120000 },
 		)
 
 		if (result.stderr) {
@@ -181,7 +180,7 @@ export const e2bProvider: DeployProvider = {
 
 		if (result.exitCode !== 0) {
 			throw new Error(
-				`Dependency installation failed (exit ${result.exitCode})`
+				`Dependency installation failed (exit ${result.exitCode})`,
 			)
 		}
 
@@ -189,7 +188,7 @@ export const e2bProvider: DeployProvider = {
 		console.log("\n🔧 Starting agent...")
 		await sandbox.commands.run(
 			"cd /home/user/app && export NODE_ENV=production AGENT_PORT=8454 && nohup node server/index.cjs > /tmp/agent.log 2>&1 & echo $! > /tmp/agent.pid",
-			{ timeout: 10000 }
+			{ timeout: 10000 },
 		)
 
 		// Wait for agent health check
@@ -198,47 +197,55 @@ export const e2bProvider: DeployProvider = {
 		for (let i = 0; i < 15; i++) {
 			try {
 				const health = await sandbox.commands.run(
-					"curl -sf http://localhost:8454/health || echo 'not ready'"
+					"curl -sf http://localhost:8454/health || echo 'not ready'",
 				)
 				if (health.stdout && !health.stdout.includes("not ready")) {
 					ready = true
 					break
 				}
 			} catch {
-				// Agent not ready yet
+				// Not ready yet
 			}
 			await new Promise((r) => setTimeout(r, 2000))
 		}
 
 		if (!ready) {
-			console.log("   ⚠️  Agent health check timed out (may still be starting)")
+			console.log(
+				"   ⚠️  Agent health check timed out (may still be starting)",
+			)
 		} else {
 			console.log("   ✓ Agent running")
 		}
 	},
 
 	async status(instanceId: string): Promise<InstanceStatus> {
-		// Check if we have the sandbox cached
 		const cached = sandboxes.get(instanceId)
 		if (cached) {
 			return "running"
 		}
 
-		// Query E2B for sandbox state
 		try {
-			const Sandbox = await importSDK()
-			const list = await Sandbox.list({ limit: 50 })
-			const found = list.find(
-				(s: any) =>
-					s.sandboxId === instanceId || s.sandboxId?.startsWith(instanceId)
-			)
-			if (!found) {
-				return "stopped"
+			const Sandbox = await getSDK()
+			const paginator = Sandbox.list()
+			while (paginator.hasNext) {
+				const items = await paginator.nextItems()
+				const found = items.find(
+					(s: { sandboxId: string }) =>
+						s.sandboxId === instanceId ||
+						s.sandboxId?.startsWith(instanceId),
+				)
+				if (found) {
+					const info = found as any
+					if (info.status === "paused") {
+						return "sleeping"
+					}
+					if (info.status === "running") {
+						return "running"
+					}
+					return "running"
+				}
 			}
-			if (found.status === "paused") {
-				return "sleeping"
-			}
-			return "running"
+			return "stopped"
 		} catch {
 			return "unknown"
 		}
@@ -248,7 +255,7 @@ export const e2bProvider: DeployProvider = {
 		const sandbox = sandboxes.get(instanceId)
 		if (!sandbox) {
 			throw new Error(
-				`Sandbox ${instanceId} not found in active sessions.\nCannot pause a sandbox that isn't connected.`
+				`Sandbox ${instanceId} not found in active sessions.\nCannot pause a sandbox that isn't connected.`,
 			)
 		}
 
@@ -259,17 +266,17 @@ export const e2bProvider: DeployProvider = {
 	},
 
 	async wake(instanceId: string): Promise<void> {
-		const Sandbox = await importSDK()
-		const apiKey = getAPIKey()
+		const Sandbox = await getSDK()
 
 		console.log(`\n☀️  Resuming E2B sandbox: ${instanceId}`)
 		try {
-			const sandbox = await Sandbox.resume({ sandboxId: instanceId, apiKey })
+			// Sandbox.connect auto-resumes paused sandboxes
+			const sandbox = await Sandbox.connect(instanceId)
 			sandboxes.set(instanceId, sandbox)
 			console.log("   ✓ Sandbox resumed")
-		} catch (err: any) {
+		} catch (err: unknown) {
 			throw new Error(
-				`Failed to resume sandbox: ${err.message}\nThe sandbox may have expired (E2B sandboxes have a maximum lifetime).`
+				`Failed to resume sandbox: ${err instanceof Error ? err.message : String(err)}\nThe sandbox may have expired (E2B sandboxes have a maximum lifetime).`,
 			)
 		}
 	},
@@ -278,17 +285,16 @@ export const e2bProvider: DeployProvider = {
 		const sandbox = sandboxes.get(instanceId)
 		if (!sandbox) {
 			throw new Error(
-				`Sandbox ${instanceId} not found. Wake it first with: hybrid deploy wake ${instanceId}`
+				`Sandbox ${instanceId} not found. Wake it first with: hybrid deploy wake ${instanceId}`,
 			)
 		}
 
 		if (follow) {
-			// Tail logs by polling
 			let offset = 0
 			while (true) {
 				try {
 					const result = await sandbox.commands.run(
-						`cat /tmp/agent.log 2>/dev/null || echo "No logs yet"`
+						"cat /tmp/agent.log 2>/dev/null || echo 'No logs yet'",
 					)
 					const output = result.stdout || ""
 					if (output.length > offset) {
@@ -302,7 +308,7 @@ export const e2bProvider: DeployProvider = {
 			}
 		} else {
 			const result = await sandbox.commands.run(
-				"cat /tmp/agent.log 2>/dev/null || echo 'No logs yet'"
+				"cat /tmp/agent.log 2>/dev/null || echo 'No logs yet'",
 			)
 			console.log(result.stdout || "No logs yet")
 		}
@@ -311,11 +317,9 @@ export const e2bProvider: DeployProvider = {
 	async endpoint(instanceId: string): Promise<string> {
 		const sandbox = sandboxes.get(instanceId)
 		if (!sandbox) {
-			// E2B provides a predictable URL format
 			return `https://${instanceId}-8454.e2b.dev`
 		}
 
-		// Get the actual host URL from the sandbox
 		try {
 			const host = await sandbox.getHost(8454)
 			return `https://${host}`
@@ -325,29 +329,24 @@ export const e2bProvider: DeployProvider = {
 	},
 
 	async teardown(instanceId: string): Promise<void> {
-		const Sandbox = await importSDK()
+		const Sandbox = await getSDK()
 
 		console.log(`\n🗑️  Destroying E2B sandbox: ${instanceId}`)
 		try {
-			// Kill the sandbox if we have a reference
 			const cached = sandboxes.get(instanceId)
 			if (cached) {
 				await cached.kill()
 			} else {
-				// Find by ID and kill
-				const list = await Sandbox.list({ limit: 50 })
-				const found = list.find(
-					(s: any) =>
-						s.sandboxId === instanceId || s.sandboxId?.startsWith(instanceId)
-				)
-				if (found) {
-					await found.kill()
-				}
+				// Connect then kill
+				const sandbox = await Sandbox.connect(instanceId)
+				await sandbox.kill()
 			}
 			sandboxes.delete(instanceId)
 			console.log("   ✓ Sandbox destroyed")
-		} catch (err: any) {
-			throw new Error(`Failed to destroy sandbox: ${err.message}`)
+		} catch (err: unknown) {
+			throw new Error(
+				`Failed to destroy sandbox: ${err instanceof Error ? err.message : String(err)}`,
+			)
 		}
-	}
+	},
 }

--- a/packages/cli/src/deploy/providers/e2b.provider.ts
+++ b/packages/cli/src/deploy/providers/e2b.provider.ts
@@ -1,5 +1,5 @@
-import { execFileSync, spawn } from "node:child_process"
-import { existsSync, unlinkSync, writeFileSync } from "node:fs"
+import { execFileSync } from "node:child_process"
+import { existsSync, unlinkSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
 import type {
@@ -22,6 +22,33 @@ const DEFAULT_TEMPLATE = "base"
 
 type SandboxInstance = any // eslint-disable-line @typescript-eslint/no-explicit-any
 
+// In-process cache — populated during deploy, used for subsequent ops
+// in the same CLI invocation.
+const sandboxes = new Map<string, SandboxInstance>()
+
+/** Look up a sandbox by name or ID via the E2B API. Works across CLI invocations. */
+async function findSandbox(name: string): Promise<SandboxInstance | null> {
+	const Sandbox = await getSDK()
+	const paginator = Sandbox.list()
+	while (paginator.hasNext) {
+		const items = await paginator.nextItems()
+		for (const s of items) {
+			const info = (s as unknown) as Record<string, unknown>
+			const meta = info.metadata as
+				| Record<string, string>
+				| undefined
+			if (
+				meta?.["hybrid-name"] === name ||
+				info.sandboxId === name ||
+				(info.sandboxId as string)?.startsWith(name)
+			) {
+				return s as SandboxInstance
+			}
+		}
+	}
+	return null
+}
+
 async function getSDK() {
 	try {
 		const { Sandbox } = await import("e2b")
@@ -43,7 +70,19 @@ function getAPIKey(): string {
 	return key
 }
 
-const sandboxes = new Map<string, SandboxInstance>()
+/** Get a sandbox instance, trying cache first then API lookup. */
+async function getSandbox(name: string): Promise<SandboxInstance | null> {
+	const cached = sandboxes.get(name)
+	if (cached) return cached
+
+	const found = await findSandbox(name)
+	if (!found) return null
+
+	const Sandbox = await getSDK()
+	const sandbox = await Sandbox.connect((found as any).sandboxId)
+	sandboxes.set(name, sandbox)
+	return sandbox
+}
 
 export const e2bProvider: DeployProvider = {
 	name: "e2b",
@@ -62,7 +101,6 @@ export const e2bProvider: DeployProvider = {
 		getAPIKey()
 		const Sandbox = await getSDK()
 		try {
-			// Try listing — Sandbox.list() returns a paginator in e2b v2
 			const paginator = Sandbox.list()
 			await paginator.nextItems()
 		} catch (err: unknown) {
@@ -81,46 +119,18 @@ export const e2bProvider: DeployProvider = {
 
 		console.log(`\n📦 Creating E2B sandbox: ${name}`)
 
-		// Try to resume an existing paused sandbox first
-		try {
-			const paginator = Sandbox.list()
-			let found: any = null // eslint-disable-line @typescript-eslint/no-explicit-any
-			while (paginator.hasNext) {
-				const items = await paginator.nextItems()
-				for (const s of items) {
-					const info = s as any
-					const meta = info.metadata as
-						| Record<string, string>
-						| undefined
-					if (meta?.["hybrid-name"] === name) {
-						found = info
-						break
-					}
-					if (
-						info.sandboxId === name ||
-						info.sandboxId?.startsWith(name)
-					) {
-						found = info
-						break
-					}
-				}
-				if (found) break
-			}
-
-			if (found) {
-				// connect() auto-resumes if paused
-				const sandbox = await Sandbox.connect(found.sandboxId)
-				sandboxes.set(name, sandbox)
-				console.log(
-					`   ✓ Resumed existing sandbox: ${found.sandboxId}`,
-				)
-				return found.sandboxId
-			}
-		} catch {
-			// No existing sandbox, create new
+		const existing = await findSandbox(name)
+		if (existing) {
+			const sandbox = await Sandbox.connect(
+				(existing as any).sandboxId,
+			)
+			sandboxes.set(name, sandbox)
+			console.log(
+				`   ✓ Resumed existing sandbox: ${(existing as any).sandboxId}`,
+			)
+			return (existing as any).sandboxId
 		}
 
-		// Create new sandbox — template is first positional arg in e2b v2
 		const sandbox = await Sandbox.create(DEFAULT_TEMPLATE, {
 			metadata: { "hybrid-name": name },
 		})
@@ -131,10 +141,10 @@ export const e2bProvider: DeployProvider = {
 	},
 
 	async deploy(instanceId: string, distDir: string): Promise<void> {
-		const sandbox = sandboxes.get(instanceId)
+		const sandbox = await getSandbox(instanceId)
 		if (!sandbox) {
 			throw new Error(
-				`Sandbox ${instanceId} not found in active sessions.\nRun 'hybrid deploy' again to reconnect.`,
+				`Sandbox ${instanceId} not found.\nRun 'hybrid deploy' again to reconnect.`,
 			)
 		}
 
@@ -167,7 +177,6 @@ export const e2bProvider: DeployProvider = {
 			}
 		}
 
-		// Extract and install deps
 		console.log("\n📦 Extracting and installing dependencies...")
 		const result = await sandbox.commands.run(
 			"cd /home/user && mkdir -p app && tar -xzf /tmp/hybrid-deploy.tar.gz -C app && cd app && npm install --production 2>&1",
@@ -184,14 +193,12 @@ export const e2bProvider: DeployProvider = {
 			)
 		}
 
-		// Start the agent
 		console.log("\n🔧 Starting agent...")
 		await sandbox.commands.run(
 			"cd /home/user/app && export NODE_ENV=production AGENT_PORT=8454 && nohup node server/index.cjs > /tmp/agent.log 2>&1 & echo $! > /tmp/agent.pid",
 			{ timeout: 10000 },
 		)
 
-		// Wait for agent health check
 		console.log("\n⏳ Waiting for agent to start...")
 		let ready = false
 		for (let i = 0; i < 15; i++) {
@@ -219,43 +226,22 @@ export const e2bProvider: DeployProvider = {
 	},
 
 	async status(instanceId: string): Promise<InstanceStatus> {
-		const cached = sandboxes.get(instanceId)
-		if (cached) {
-			return "running"
-		}
+		const sandbox = await getSandbox(instanceId)
+		if (sandbox) return "running"
 
-		try {
-			const Sandbox = await getSDK()
-			const paginator = Sandbox.list()
-			while (paginator.hasNext) {
-				const items = await paginator.nextItems()
-				const found = items.find(
-					(s: { sandboxId: string }) =>
-						s.sandboxId === instanceId ||
-						s.sandboxId?.startsWith(instanceId),
-				)
-				if (found) {
-					const info = found as any
-					if (info.status === "paused") {
-						return "sleeping"
-					}
-					if (info.status === "running") {
-						return "running"
-					}
-					return "running"
-				}
-			}
-			return "stopped"
-		} catch {
-			return "unknown"
-		}
+		const info = await findSandbox(instanceId)
+		if (!info) return "stopped"
+		const status = (info as any).status as string
+		if (status === "paused") return "sleeping"
+		if (status === "running") return "running"
+		return "unknown"
 	},
 
 	async sleep(instanceId: string): Promise<void> {
-		const sandbox = sandboxes.get(instanceId)
+		const sandbox = await getSandbox(instanceId)
 		if (!sandbox) {
 			throw new Error(
-				`Sandbox ${instanceId} not found in active sessions.\nCannot pause a sandbox that isn't connected.`,
+				`Sandbox ${instanceId} not found.\nRun 'hybrid deploy' again to reconnect.`,
 			)
 		}
 
@@ -270,7 +256,6 @@ export const e2bProvider: DeployProvider = {
 
 		console.log(`\n☀️  Resuming E2B sandbox: ${instanceId}`)
 		try {
-			// Sandbox.connect auto-resumes paused sandboxes
 			const sandbox = await Sandbox.connect(instanceId)
 			sandboxes.set(instanceId, sandbox)
 			console.log("   ✓ Sandbox resumed")
@@ -282,10 +267,10 @@ export const e2bProvider: DeployProvider = {
 	},
 
 	async logs(instanceId: string, follow = true): Promise<void> {
-		const sandbox = sandboxes.get(instanceId)
+		const sandbox = await getSandbox(instanceId)
 		if (!sandbox) {
 			throw new Error(
-				`Sandbox ${instanceId} not found. Wake it first with: hybrid deploy wake ${instanceId}`,
+				`Sandbox ${instanceId} not found.\nRun 'hybrid deploy' again to reconnect.`,
 			)
 		}
 
@@ -316,9 +301,7 @@ export const e2bProvider: DeployProvider = {
 
 	async endpoint(instanceId: string): Promise<string> {
 		const sandbox = sandboxes.get(instanceId)
-		if (!sandbox) {
-			return `https://${instanceId}-8454.e2b.dev`
-		}
+		if (!sandbox) return `https://${instanceId}-8454.e2b.dev`
 
 		try {
 			const host = await sandbox.getHost(8454)
@@ -337,7 +320,6 @@ export const e2bProvider: DeployProvider = {
 			if (cached) {
 				await cached.kill()
 			} else {
-				// Connect then kill
 				const sandbox = await Sandbox.connect(instanceId)
 				await sandbox.kill()
 			}

--- a/packages/cli/src/deploy/providers/e2b.provider.ts
+++ b/packages/cli/src/deploy/providers/e2b.provider.ts
@@ -22,11 +22,10 @@ const DEFAULT_TEMPLATE = "base"
 
 type SandboxInstance = any // eslint-disable-line @typescript-eslint/no-explicit-any
 
-// In-process cache — populated during deploy, used for subsequent ops
-// in the same CLI invocation.
 const sandboxes = new Map<string, SandboxInstance>()
 
-/** Look up a sandbox by name or ID via the E2B API. Works across CLI invocations. */
+/** Look up a sandbox by name or ID via the E2B API. Works across CLI invocations.
+ *  Status-only — does NOT call connect(), so it won't auto-resume paused sandboxes. */
 async function findSandbox(name: string): Promise<SandboxInstance | null> {
 	const Sandbox = await getSDK()
 	const paginator = Sandbox.list()
@@ -70,7 +69,8 @@ function getAPIKey(): string {
 	return key
 }
 
-/** Get a sandbox instance, trying cache first then API lookup. */
+/** Get a sandbox instance, trying cache first then API lookup + connect.
+ *  Connect will auto-resume paused sandboxes. */
 async function getSandbox(name: string): Promise<SandboxInstance | null> {
 	const cached = sandboxes.get(name)
 	if (cached) return cached
@@ -226,14 +226,13 @@ export const e2bProvider: DeployProvider = {
 	},
 
 	async status(instanceId: string): Promise<InstanceStatus> {
-		const sandbox = await getSandbox(instanceId)
-		if (sandbox) return "running"
-
+		// NOTE: Must use findSandbox only — doGetSandbox() calls connect()
+		// which auto-resumes paused sandboxes, so status would never show "sleeping".
 		const info = await findSandbox(instanceId)
 		if (!info) return "stopped"
-		const status = (info as any).status as string
-		if (status === "paused") return "sleeping"
-		if (status === "running") return "running"
+		const sbInfo = info as any
+		if (sbInfo.status === "paused") return "sleeping"
+		if (sbInfo.status === "running") return "running"
 		return "unknown"
 	},
 

--- a/packages/cli/src/deploy/providers/northflank.provider.ts
+++ b/packages/cli/src/deploy/providers/northflank.provider.ts
@@ -334,7 +334,7 @@ export const northflankProvider: DeployProvider = {
 
 	async endpoint(instanceId: string): Promise<string> {
 		const projectId = process.env.NF_PROJECT_ID
-		if (!projectId) return `https://${instanceId}.${projectId}.northflank.app`
+		if (!projectId) return `https://${instanceId}.northflank.app`
 
 		try {
 			// Try to get the actual URL from the service info

--- a/packages/cli/src/deploy/providers/northflank.provider.ts
+++ b/packages/cli/src/deploy/providers/northflank.provider.ts
@@ -1,0 +1,381 @@
+import { execFileSync, spawn } from "node:child_process"
+import { existsSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
+import type {
+	DeployProvider,
+	InstanceStatus,
+	ProvisionOpts
+} from "../deploy-provider"
+
+// ============================================================================
+// Northflank Provider
+//
+// Uses the `nf` CLI (or direct API calls) for service management.
+// Northflank deploys Docker containers on Firecracker VMs with
+// auto-scale-to-zero support.
+//
+// Sleep/wake: Scale replicas to 0 (sleep) → inbound request triggers auto-scale to 1 (wake)
+//             Platform manages the cold start automatically.
+// ============================================================================
+
+const CLI = "nf"
+
+function runNf(args: string[]): string {
+	return execFileSync(CLI, args, {
+		encoding: "utf-8",
+		stdio: ["pipe", "pipe", "pipe"]
+	})
+}
+
+function runNfInherit(args: string[]): void {
+	execFileSync(CLI, args, { stdio: "inherit" })
+}
+
+export const northflankProvider: DeployProvider = {
+	name: "northflank",
+	label: "Northflank (Firecracker / Auto-scale)",
+
+	defaultName(projectDir: string): string {
+		return basename(projectDir)
+			.toLowerCase()
+			.replace(/[^a-z0-9-]/g, "-")
+			.replace(/-+/g, "-")
+			.replace(/^-+|-+$/g, "")
+			.slice(0, 40)
+	},
+
+	async authCheck(): Promise<void> {
+		try {
+			const result = runNf(["auth", "whoami"])
+			if (!result || result.includes("not logged in")) {
+				throw new Error(
+					"Not authenticated with Northflank.\n    Run: nf auth login"
+				)
+			}
+		} catch (err: any) {
+			if (err.code === "ENOENT") {
+				throw new Error(
+					"`nf` CLI not found.\n    Install: https://docs.northflank.com/docs/cli\n    Or: npm install -g @northflank/cli"
+				)
+			}
+			throw new Error(
+				`Northflank CLI error: ${err.stderr || err.message}\nRun: nf auth login`
+			)
+		}
+	},
+
+	async provision(name: string, opts?: ProvisionOpts): Promise<string> {
+		// Northflank provision = create a service via API
+		// We use the CLI to check if a service already exists
+		const projectId = process.env.NF_PROJECT_ID
+		if (!projectId) {
+			throw new Error(
+				"NF_PROJECT_ID not set.\n    Create a project on Northflank and set: export NF_PROJECT_ID=your-project-id"
+			)
+		}
+
+		// Check if service already exists
+		try {
+			const existing = runNf(["services", "list", "--projectId", projectId])
+			if (existing.toLowerCase().includes(name)) {
+				console.log(`   ✓ Service already exists: ${name}`)
+				return name
+			}
+		} catch {
+			// Service doesn't exist, create it
+		}
+
+		// Create the service using the Northflank API
+		// The nf CLI doesn't support create for all service types, so we use the API
+		const apiUrl = process.env.NF_API_URL || "https://api.northflank.com"
+		const memory = opts?.memory || 512
+		const cpus = opts?.cpus || 1
+
+		console.log(`\n📦 Creating Northflank service: ${name}`)
+		console.log(`   Project: ${projectId}`)
+		console.log(`   Memory: ${memory}MB, CPUs: ${cpus}`)
+
+		// Build the service spec JSON
+		const spec = {
+			name: name,
+			projectId: projectId,
+			type: "service",
+			image: {
+				image: `registry.northflank.com/${projectId}/${name}:latest`
+			},
+			resources: {
+				instances: 1,
+				containerResources: {
+					cpu: {
+						req: cpus,
+						limit: cpus
+					},
+					memory: {
+						req: memory,
+						limit: memory
+					}
+				}
+			},
+			ports: [
+				{
+					name: "default",
+					protocol: "HTTP",
+					containerPort: 8454,
+					ingress: {
+						autoSubdomain: true
+					}
+				}
+			],
+			autoscaling: {
+				enabled: true,
+				minReplicas: 0,
+				maxReplicas: 1
+			}
+		}
+
+		const specPath = join(tmpdir(), `nf-spec-${Date.now()}.json`)
+		const { writeFileSync } = await import("node:fs")
+		writeFileSync(specPath, JSON.stringify(spec, null, 2))
+
+		// Use nf deploy or the API to create the service
+		try {
+			runNfInherit(["deploy", "service", specPath])
+		} finally {
+			if (existsSync(specPath)) {
+				try {
+					unlinkSync(specPath)
+				} catch {}
+			}
+		}
+
+		console.log("   ✓ Service created with auto-scale-to-zero enabled")
+		return name
+	},
+
+	async deploy(instanceId: string, distDir: string): Promise<void> {
+		const projectId = process.env.NF_PROJECT_ID
+		if (!projectId) {
+			throw new Error("NF_PROJECT_ID not set.")
+		}
+
+		console.log("\n📦 Building and pushing Docker image...")
+
+		// Build Docker image from dist
+		const imageTag = `registry.northflank.com/${projectId}/${instanceId}:latest`
+
+		// Check if docker is available
+		runNf(["info"]) // Just to verify CLI works
+
+		// Build the image
+		console.log("   Building Docker image...")
+		execFileSync("docker", ["build", "-t", imageTag, "."], {
+			cwd: distDir,
+			stdio: "inherit"
+		})
+
+		// Push the image
+		console.log("   Pushing to Northflank registry...")
+		execFileSync("docker", ["push", imageTag], {
+			stdio: "inherit"
+		})
+
+		// Deploy/update the service with the new image
+		console.log("\n🔧 Deploying service...")
+		try {
+			runNfInherit([
+				"services",
+				"set-image",
+				"--projectId",
+				projectId,
+				"--serviceId",
+				instanceId,
+				"--image",
+				imageTag
+			])
+		} catch (err: any) {
+			// Service may already be deploying, ignore
+			console.log("   ⚠️  Service update initiated")
+		}
+
+		// Wait for deployment to be ready
+		console.log("\n⏳ Waiting for deployment to be ready...")
+		for (let i = 0; i < 60; i++) {
+			try {
+				const status = runNf([
+					"services",
+					"status",
+					"--projectId",
+					projectId,
+					"--serviceId",
+					instanceId
+				])
+				if (
+					status.toLowerCase().includes("deployed") ||
+					status.toLowerCase().includes("running")
+				) {
+					console.log("   ✓ Service deployed")
+					return
+				}
+			} catch {
+				// Not ready yet
+			}
+			if (i % 10 === 9) {
+				console.log(`   Still deploying... (${i + 1}/60)`)
+			}
+			await new Promise((r) => setTimeout(r, 5000))
+		}
+
+		console.log("   ⚠️  Deployment may still be in progress")
+	},
+
+	async status(instanceId: string): Promise<InstanceStatus> {
+		const projectId = process.env.NF_PROJECT_ID
+		if (!projectId) return "unknown"
+
+		try {
+			const status = runNf([
+				"services",
+				"status",
+				"--projectId",
+				projectId,
+				"--serviceId",
+				instanceId
+			])
+
+			const lower = status.toLowerCase()
+			if (lower.includes("deployed") || lower.includes("running")) {
+				return "running"
+			}
+			if (lower.includes("stopped") || lower.includes("paused")) {
+				return "sleeping"
+			}
+			if (lower.includes("deploying")) {
+				return "provisioning"
+			}
+			return "unknown"
+		} catch {
+			return "stopped"
+		}
+	},
+
+	async sleep(instanceId: string): Promise<void> {
+		const projectId = process.env.NF_PROJECT_ID
+		if (!projectId) {
+			throw new Error("NF_PROJECT_ID not set.")
+		}
+
+		console.log(`\n💤 Scaling Northflank service to 0: ${instanceId}`)
+		try {
+			runNfInherit([
+				"services",
+				"scale",
+				"--projectId",
+				projectId,
+				"--serviceId",
+				instanceId,
+				"--replicas",
+				"0"
+			])
+			console.log("   ✓ Service scaled to 0 (sleeping)")
+		} catch (err: any) {
+			throw new Error(`Failed to scale down: ${err.stderr || err.message}`)
+		}
+	},
+
+	async wake(instanceId: string): Promise<void> {
+		const projectId = process.env.NF_PROJECT_ID
+		if (!projectId) {
+			throw new Error("NF_PROJECT_ID not set.")
+		}
+
+		console.log(`\n☀️  Scaling Northflank service to 1: ${instanceId}`)
+		try {
+			runNfInherit([
+				"services",
+				"scale",
+				"--projectId",
+				projectId,
+				"--serviceId",
+				instanceId,
+				"--replicas",
+				"1"
+			])
+			console.log("   ✓ Service scaling up (may take 30-60s)")
+		} catch (err: any) {
+			throw new Error(`Failed to scale up: ${err.stderr || err.message}`)
+		}
+	},
+
+	async logs(instanceId: string, follow = true): Promise<void> {
+		const projectId = process.env.NF_PROJECT_ID
+		if (!projectId) {
+			throw new Error("NF_PROJECT_ID not set.")
+		}
+
+		const args = [
+			"services",
+			"logs",
+			"--projectId",
+			projectId,
+			"--serviceId",
+			instanceId
+		]
+		if (follow) args.push("--follow")
+
+		const child = spawn(CLI, args, { stdio: "inherit" })
+		return new Promise((resolve, reject) => {
+			child.on("exit", (code) => {
+				if (code === 0) resolve()
+				else reject(new Error(`nf logs exited with code ${code}`))
+			})
+		})
+	},
+
+	async endpoint(instanceId: string): Promise<string> {
+		const projectId = process.env.NF_PROJECT_ID
+		if (!projectId) return `https://${instanceId}.${projectId}.northflank.app`
+
+		try {
+			// Try to get the actual URL from the service info
+			const info = runNf([
+				"services",
+				"info",
+				"--projectId",
+				projectId,
+				"--serviceId",
+				instanceId
+			])
+			// Parse URL from service info
+			const match = info.match(/https?:\/\/[^\s]+/i)
+			if (match) return match[0]
+		} catch {
+			// Fallback to predicted URL
+		}
+
+		return `https://${instanceId}.${projectId}.northflank.app`
+	},
+
+	async teardown(instanceId: string): Promise<void> {
+		const projectId = process.env.NF_PROJECT_ID
+		if (!projectId) {
+			throw new Error("NF_PROJECT_ID not set.")
+		}
+
+		console.log(`\n🗑️  Destroying Northflank service: ${instanceId}`)
+		try {
+			runNfInherit([
+				"services",
+				"delete",
+				"--projectId",
+				projectId,
+				"--serviceId",
+				instanceId,
+				"--permanent"
+			])
+			console.log("   ✓ Service destroyed")
+		} catch (err: any) {
+			throw new Error(`Failed to destroy service: ${err.stderr || err.message}`)
+		}
+	}
+}

--- a/packages/cli/src/deploy/providers/sprite.provider.ts
+++ b/packages/cli/src/deploy/providers/sprite.provider.ts
@@ -1,0 +1,332 @@
+import { execFileSync, spawn } from "node:child_process"
+import { existsSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
+import type {
+	DeployProvider,
+	InstanceStatus,
+	ProvisionOpts
+} from "../deploy-provider"
+
+// ============================================================================
+// Sprites.dev Provider
+// ============================================================================
+
+export const spriteProvider: DeployProvider = {
+	name: "sprites",
+	label: "Sprites.dev (Firecracker)",
+
+	defaultName(projectDir: string): string {
+		// Sanitize: sprites.dev names must be lowercase alphanumeric + hyphens
+		return basename(projectDir)
+			.toLowerCase()
+			.replace(/[^a-z0-9-]/g, "-")
+			.replace(/-+/g, "-")
+			.replace(/^-+|-+$/g, "")
+			.slice(0, 40)
+	},
+
+	async authCheck(): Promise<void> {
+		try {
+			execFileSync("sprite", ["list"], { stdio: "pipe", timeout: 5000 })
+		} catch (err: any) {
+			if (err.code === "ENOENT") {
+				throw new Error(
+					"'sprite' CLI not found.\n" +
+						"   Install: https://sprites.dev/docs/install\n" +
+						"   Or: npm i -g sprite-cli"
+				)
+			}
+			throw new Error(
+				`Sprite CLI authentication failed.\n   Run: sprite login\n   Error: ${err.stderr || err.message}`
+			)
+		}
+	},
+
+	async provision(name: string, _opts?: ProvisionOpts): Promise<string> {
+		// Validate name
+		if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(name)) {
+			throw new Error(
+				`Invalid sprite name: ${name}\nName must start with a letter/digit and contain only letters, digits, hyphens, and underscores.`
+			)
+		}
+
+		// Check if sprite already exists
+		try {
+			const existing = execFileSync("sprite", ["list"], {
+				encoding: "utf-8"
+			})
+			if (existing.includes(name)) {
+				return name
+			}
+		} catch {
+			// sprite list failed for some reason, try to create anyway
+		}
+
+		console.log(`\n📦 Creating sprite: ${name}`)
+		try {
+			execFileSync("sprite", ["create", "-skip-console", name], {
+				stdio: "inherit"
+			})
+		} catch {
+			// May already exist (race condition) — verify
+			const existing = execFileSync("sprite", ["list"], {
+				encoding: "utf-8"
+			})
+			if (existing.includes(name)) {
+				console.log(`   Sprite ${name} already exists, using it`)
+				return name
+			}
+			throw new Error("Failed to create sprite")
+		}
+
+		// Wait for sprite to be ready
+		console.log("\n⏳ Waiting for sprite to be ready...")
+		for (let i = 0; i < 30; i++) {
+			try {
+				execFileSync("sprite", ["exec", "-s", name, "--", "echo", "ready"], {
+					stdio: "pipe"
+				})
+				console.log("   ✓ Sprite ready")
+				return name
+			} catch {
+				if (i % 5 === 4) {
+					console.log(`   Still waiting... (${i + 1}/30)`)
+				}
+				await new Promise((r) => setTimeout(r, 2000))
+			}
+		}
+
+		throw new Error("Sprite did not become ready in time")
+	},
+
+	async deploy(instanceId: string, distDir: string): Promise<void> {
+		console.log("\n📤 Uploading build artifacts...")
+		const tarPath = join(tmpdir(), `hybrid-deploy-${Date.now()}.tar.gz`)
+
+		// Create tarball
+		execFileSync("tar", ["-czf", tarPath, "-C", distDir, "."], {
+			stdio: "pipe"
+		})
+
+		// Ensure /app directory exists
+		execFileSync(
+			"sprite",
+			["exec", "-s", instanceId, "--", "mkdir", "-p", "/app"],
+			{
+				stdio: "pipe"
+			}
+		)
+
+		// Upload and extract (retry up to 3 times)
+		let uploadSuccess = false
+		for (let attempt = 0; attempt < 3; attempt++) {
+			try {
+				execFileSync(
+					"sprite",
+					[
+						"exec",
+						"-s",
+						instanceId,
+						"-file",
+						`${tarPath}:/tmp/hybrid-deploy.tar.gz`,
+						"--",
+						"tar",
+						"-xzf",
+						"/tmp/hybrid-deploy.tar.gz",
+						"-C",
+						"/app"
+					],
+					{ stdio: "inherit" }
+				)
+				uploadSuccess = true
+				break
+			} catch {
+				if (attempt < 2) {
+					console.log(`   Upload failed, retrying... (${attempt + 1}/3)`)
+					await new Promise((r) => setTimeout(r, 5000))
+				}
+			}
+		}
+
+		// Clean up local tarball
+		if (existsSync(tarPath)) {
+			try {
+				unlinkSync(tarPath)
+			} catch {}
+		}
+
+		if (!uploadSuccess) {
+			throw new Error("Failed to upload build artifacts after 3 attempts")
+		}
+
+		// Install dependencies
+		console.log("\n📦 Installing dependencies...")
+		execFileSync(
+			"sprite",
+			[
+				"exec",
+				"-s",
+				instanceId,
+				"--",
+				"bash",
+				"-c",
+				"cd /app && npm install --production"
+			],
+			{ stdio: "inherit" }
+		)
+
+		// Set up and start the agent
+		console.log("\n🔧 Starting agent...")
+		const { writeFileSync } = await import("node:fs")
+		const scriptPath = join(tmpdir(), `hybrid-start-${Date.now()}.sh`)
+		const startupScript = `#!/bin/bash
+cd /app
+export NODE_ENV=production
+export AGENT_PORT=8454
+exec nohup node server/index.cjs > /app/agent.log 2>&1 &
+echo $! > /app/agent.pid
+`
+		writeFileSync(scriptPath, startupScript, { mode: 0o755 })
+
+		execFileSync(
+			"sprite",
+			[
+				"exec",
+				"-s",
+				instanceId,
+				"-file",
+				`${scriptPath}:/app/start-agent.sh`,
+				"--",
+				"chmod",
+				"+x",
+				"/app/start-agent.sh"
+			],
+			{ stdio: "pipe" }
+		)
+
+		execFileSync(
+			"sprite",
+			["exec", "-s", instanceId, "--", "bash", "/app/start-agent.sh"],
+			{ stdio: "inherit" }
+		)
+
+		try {
+			unlinkSync(scriptPath)
+		} catch {}
+
+		// Wait for agent to be ready
+		console.log("\n⏳ Waiting for agent to start...")
+		let ready = false
+		for (let i = 0; i < 15; i++) {
+			try {
+				const result = execFileSync(
+					"sprite",
+					[
+						"exec",
+						"-s",
+						instanceId,
+						"--",
+						"curl",
+						"-s",
+						"http://localhost:8454/health"
+					],
+					{ encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+				)
+				if (result) {
+					ready = true
+					break
+				}
+			} catch {
+				// Agent not ready yet
+			}
+			await new Promise((r) => setTimeout(r, 2000))
+		}
+
+		if (!ready) {
+			console.log("   ⚠️  Agent may not be fully ready (health check timed out)")
+		} else {
+			console.log("   ✓ Agent running")
+		}
+	},
+
+	async status(instanceId: string): Promise<InstanceStatus> {
+		try {
+			const output = execFileSync("sprite", ["list"], {
+				encoding: "utf-8"
+			})
+			if (!output.includes(instanceId)) {
+				return "stopped"
+			}
+			// Parse sprite list output to determine state
+			// This is heuristic — sprites.list format may vary
+			const lines = output.split("\n")
+			for (const line of lines) {
+				if (line.includes(instanceId)) {
+					if (line.includes("sleeping") || line.includes("paused")) {
+						return "sleeping"
+					}
+					if (line.includes("running")) {
+						return "running"
+					}
+					if (line.includes("stopped") || line.includes("terminated")) {
+						return "stopped"
+					}
+					return "running" // assume running if found and no explicit state
+				}
+			}
+			return "unknown"
+		} catch {
+			return "unknown"
+		}
+	},
+
+	async sleep(instanceId: string): Promise<void> {
+		console.log(`\n💤 Sleeping sprite: ${instanceId}`)
+		try {
+			execFileSync("sprite", ["sleep", instanceId], { stdio: "inherit" })
+			console.log("   ✓ Sprite sleeping")
+		} catch (err: any) {
+			throw new Error(`Failed to sleep sprite: ${err.stderr || err.message}`)
+		}
+	},
+
+	async wake(instanceId: string): Promise<void> {
+		console.log(`\n☀️  Waking sprite: ${instanceId}`)
+		try {
+			execFileSync("sprite", ["exec", "-s", instanceId, "--", "echo", "wake"], {
+				stdio: "pipe"
+			})
+			console.log("   ✓ Sprite awake")
+		} catch (err: any) {
+			throw new Error(`Failed to wake sprite: ${err.stderr || err.message}`)
+		}
+	},
+
+	async logs(instanceId: string, follow = true): Promise<void> {
+		const args = follow
+			? ["logs", "-s", instanceId, "-f"]
+			: ["logs", "-s", instanceId]
+		const child = spawn("sprite", args, { stdio: "inherit" })
+		return new Promise((resolve, reject) => {
+			child.on("exit", (code) => {
+				if (code === 0) resolve()
+				else reject(new Error(`sprite logs exited with code ${code}`))
+			})
+		})
+	},
+
+	async endpoint(instanceId: string): Promise<string> {
+		return `https://${instanceId}.sprites.dev`
+	},
+
+	async teardown(instanceId: string): Promise<void> {
+		console.log(`\n🗑️  Destroying sprite: ${instanceId}`)
+		try {
+			execFileSync("sprite", ["delete", instanceId], { stdio: "inherit" })
+			console.log("   ✓ Sprite destroyed")
+		} catch (err: any) {
+			throw new Error(`Failed to destroy sprite: ${err.stderr || err.message}`)
+		}
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,9 @@ importers:
         specifier: ^4.0.0
         version: 4.3.6
     optionalDependencies:
+      e2b:
+        specifier: ^2.19.0
+        version: 2.19.0
       node-llama-cpp:
         specifier: ^3.0.0
         version: 3.17.1(typescript@5.9.3)
@@ -622,6 +625,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@bufbuild/protobuf@2.11.0':
+    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+
   '@chat-adapter/discord@4.25.0':
     resolution: {integrity: sha512-fV5XwPyfXiuiAE6gyNhBVg/fi+fkE0ovkOE8ANT6PAPNYnMvegtAt72oLvDvkSbujpngzXMlrUs6+l0sxAHC2g==}
 
@@ -699,6 +705,17 @@ packages:
 
   '@cloudflare/workers-types@4.20260228.0':
     resolution: {integrity: sha512-9LfRg93ncQq6Oc4MFpqGSs+PmPhqWvg8TspXwbiYNR201IhXB4WqHR/aTSudPI0ujsf/NLc8E9fF3C+aA2g8KQ==}
+
+  '@connectrpc/connect-web@2.0.0-rc.3':
+    resolution: {integrity: sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.2.0
+      '@connectrpc/connect': 2.0.0-rc.3
+
+  '@connectrpc/connect@2.0.0-rc.3':
+    resolution: {integrity: sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.2.0
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1254,6 +1271,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -2394,6 +2415,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2420,6 +2445,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2591,6 +2620,9 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
@@ -2728,6 +2760,9 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dockerfile-ast@0.7.1:
+    resolution: {integrity: sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -2735,6 +2770,10 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  e2b@2.19.0:
+    resolution: {integrity: sha512-Tpm5F6BJAkRoSXqBA1/VLHn/OP4mCsDTX0FWP6UMxC2MU26nJ2fXgPZNdYOyTvi4gyNd1GeEQzUCbAmODh/GuQ==}
+    engines: {node: '>=20'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -3153,6 +3192,12 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   global-modules@1.0.0:
     resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
     engines: {node: '>=0.10.0'}
@@ -3427,6 +3472,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
   jiti@2.6.0:
     resolution: {integrity: sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==}
     hasBin: true
@@ -3592,6 +3641,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
 
   lucide-react@0.570.0:
     resolution: {integrity: sha512-qGnQ8bEPJLMseKo7kI6jK6GW6Y2Yl4PpqoWbroNsobZ8+tZR4SUuO4EXK3oWCdZr48SZ7PnaulTkvzkKvG/Iqg==}
@@ -3843,6 +3896,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4046,6 +4103,12 @@ packages:
       zod:
         optional: true
 
+  openapi-fetch@0.14.1:
+    resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
@@ -4130,6 +4193,10 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -4202,6 +4269,9 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   plop@4.0.3:
     resolution: {integrity: sha512-iDD7f+y8Ula3jpPtawc6zipkCIY4w14lynSVXv7GlRDBHRT7vzThzZaugFrXN8Zul4rekXjJmfpeqoKDOC4txg==}
@@ -4779,6 +4849,10 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+
   tar@7.5.9:
     resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
     engines: {node: '>=18'}
@@ -5189,6 +5263,12 @@ packages:
       jsdom:
         optional: true
 
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -5445,6 +5525,9 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
+  '@bufbuild/protobuf@2.11.0':
+    optional: true
+
   '@chat-adapter/discord@4.25.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@chat-adapter/shared': 4.25.0
@@ -5520,6 +5603,17 @@ snapshots:
     optional: true
 
   '@cloudflare/workers-types@4.20260228.0': {}
+
+  '@connectrpc/connect-web@2.0.0-rc.3(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.11.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.11.0)
+    optional: true
+
+  '@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.11.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -5897,6 +5991,9 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/cliui@9.0.0':
+    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -7030,6 +7127,9 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4:
+    optional: true
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.0: {}
@@ -7068,6 +7168,11 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+    optional: true
 
   braces@3.0.3:
     dependencies:
@@ -7233,6 +7338,9 @@ snapshots:
 
   commander@4.1.1: {}
 
+  compare-versions@6.1.1:
+    optional: true
+
   compute-scroll-into-view@3.1.1: {}
 
   concurrently@9.2.1:
@@ -7346,6 +7454,12 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dockerfile-ast@0.7.1:
+    dependencies:
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+    optional: true
+
   dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
@@ -7353,6 +7467,20 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  e2b@2.19.0:
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.11.0)
+      '@connectrpc/connect-web': 2.0.0-rc.3(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.0.0-rc.3(@bufbuild/protobuf@2.11.0))
+      chalk: 5.6.2
+      compare-versions: 6.1.1
+      dockerfile-ast: 0.7.1
+      glob: 11.1.0
+      openapi-fetch: 0.14.1
+      platform: 1.3.6
+      tar: 7.5.13
+    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -7844,6 +7972,16 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+    optional: true
+
   global-modules@1.0.0:
     dependencies:
       global-prefix: 1.0.2
@@ -8200,6 +8338,11 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+    optional: true
+
   jiti@2.6.0:
     optional: true
 
@@ -8337,6 +8480,9 @@ snapshots:
     optional: true
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.3.5:
+    optional: true
 
   lucide-react@0.570.0(react@19.2.3):
     dependencies:
@@ -8857,6 +9003,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+    optional: true
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
@@ -9154,6 +9305,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  openapi-fetch@0.14.1:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+    optional: true
+
+  openapi-typescript-helpers@0.0.15:
+    optional: true
+
   ora@5.4.1:
     dependencies:
       bl: 4.1.0
@@ -9268,6 +9427,12 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.2
+    optional: true
+
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.3.0: {}
@@ -9328,6 +9493,9 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+
+  platform@1.3.6:
+    optional: true
 
   plop@4.0.3(@types/node@22.17.2):
     dependencies:
@@ -10037,6 +10205,15 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
+    optional: true
+
   tar@7.5.9:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -10586,6 +10763,12 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vscode-languageserver-textdocument@1.0.12:
+    optional: true
+
+  vscode-languageserver-types@3.17.5:
+    optional: true
 
   wcwidth@1.0.1:
     dependencies:

--- a/specs/cli-deploy-firecracker/SPEC.md
+++ b/specs/cli-deploy-firecracker/SPEC.md
@@ -1,0 +1,404 @@
+# CLI Deploy: Firecracker microVM Providers
+
+## Overview
+
+Hybrid agents deploy to **Firecracker microVMs** that sleep when idle and wake on demand to handle incoming messages. User picks their Firecracker provider at deploy time via `hybrid deploy [platform]`.
+
+> **Related:** [HYBRID-140](https://linear.app/01studio/issue/HYBRID-140) — Phase 4: Firecracker microVM deployment (sleep/wake agents)
+
+---
+
+## Supported Platforms
+
+| Provider       | CLI/SDK       | Sleep             | Wake                  | Notes                          |
+|----------------|---------------|-------------------|-----------------------|--------------------------------|
+| `sprites`      | `sprite` CLI  | `sprite sleep`    | `sprite exec` (proxy) | Reference implementation (T1)  |
+| `e2b`          | `@e2b/sdk`    | `sandbox.pause()` | `sandbox.resume()`    | Native pause/resume (T1)       |
+| `daytona`      | `daytona` CLI | `daytona stop`    | `daytona start`       | Slow wake ~30s (T2)            |
+| `northflank`   | `nf` CLI      | auto-scale to 0   | inbound request       | Platform-managed (T1)          |
+
+**Priority order:**
+1. **sprites** — already partially implemented (PR #150), extract and formalize
+2. **e2b** — strong SDK, best dev experience after sprites
+3. **northflank** — production-grade, auto-scale-to-zero
+4. **daytona** — dev-environment oriented, slowest wake
+
+---
+
+## Architecture
+
+### Directory Structure
+
+```
+packages/cli/src/deploy/
+├── deploy-provider.ts    # DeployProvider interface, types, shared utilities
+├── deploy.ts             # Unified deploy orchestration (pick provider → build → provision → deploy → sleep)
+├── providers/
+│   ├── sprite.provider.ts     # sprites.dev adapter
+│   ├── e2b.provider.ts        # e2b.dev adapter
+│   ├── northflank.provider.ts # northflank adapter
+│   └── daytona.provider.ts    # daytona.io adapter
+└── index.ts              # Re-exports
+```
+
+The main CLI (`cli.ts`) delegates to `deploy()` with the platform string. No platform logic lives in `cli.ts`.
+
+### DeployProvider Interface
+
+```typescript
+export interface DeployProvider {
+  /** Unique provider identifier: "sprites" | "e2b" | "northflank" | "daytona" */
+  readonly name: string;
+
+  /** Human-readable label for CLI prompts */
+  readonly label: string;
+
+  /** Default instance name when user doesn't specify one */
+  defaultName(projectDir: string): string;
+
+  /**
+   * Verify prerequisites: CLI installed, authenticated, accessible.
+   * Throws with a helpful message if requirements aren't met.
+   */
+  authCheck(): Promise<void>;
+
+  /**
+   * Provision a new Firecracker microVM.
+   * Returns an instance ID or name used for subsequent operations.
+   */
+  provision(name: string, opts?: ProvisionOpts): Promise<string>;
+
+  /**
+   * Push the built agent bundle (from distDir) into the running VM.
+   * Handles uploading, extracting, installing deps.
+   */
+  deploy(instanceId: string, distDir: string): Promise<void>;
+
+  /**
+   * Return current lifecycle state of the instance.
+   */
+  status(instanceId: string): Promise<InstanceStatus>;
+
+  /**
+   * Put the VM to sleep (pause, stop, or scale-to-zero depending on provider).
+   */
+  sleep(instanceId: string): Promise<void>;
+
+  /**
+   * Wake the VM from sleep (resume, start, or trigger cold start).
+   */
+  wake(instanceId: string): Promise<void>;
+
+  /**
+   * Stream logs from the agent process.
+   */
+  logs(instanceId: string, follow?: boolean): Promise<void>;
+
+  /**
+   * Return the public-facing endpoint URL for the agent.
+   */
+  endpoint(instanceId: string): Promise<string>;
+
+  /**
+   * Destroy the VM and all associated resources.
+   */
+  teardown(instanceId: string): Promise<void>;
+}
+
+export interface ProvisionOpts {
+  /** Memory in MB (provider-specific defaults if omitted) */
+  memory?: number;
+  /** vCPU count (provider-specific defaults if omitted) */
+  cpus?: number;
+  /** Environment variables to set on the instance */
+  env?: Record<string, string>;
+}
+
+export type InstanceStatus =
+  | "running"
+  | "sleeping"
+  | "stopped"
+  | "provisioning"
+  | "error"
+  | "unknown";
+```
+
+### Deploy Orchestration (`deploy.ts`)
+
+```
+deploy(platform?)
+  ├─ resolve platform (arg → hybrid.config.ts → interactive prompt)
+  ├─ load provider by name
+  ├─ provider.authCheck()     → bail if not ready
+  ├─ build("firecracker")     → produce dist/
+  ├─ pick instance name       (ENV → config → default)
+  ├─ provider.status(name)
+  │   ├─ running   → confirm reuse or force recreate
+  │   └─ otherwise → provider.provision(name)
+  ├─ provider.deploy(instanceId, distDir)
+  └─ provider.endpoint(instanceId) → print URLs + next steps
+```
+
+### CLI Commands Added/Modified
+
+```
+hybrid deploy [platform]              Deploy to a Firecracker provider
+hybrid deploy:sleep <name> [--provider sprites|e2b|...]   Put VM to sleep
+hybrid deploy:wake <name>  [--provider sprites|e2b|...]   Wake VM
+hybrid deploy:status <name> [--provider sprites|e2b|...]  Show VM status
+hybrid deploy:logs <name> [--provider sprites|e2b|...]    Stream agent logs
+hybrid deploy:teardown <name> [--all]                     Destroy VM(s)
+```
+
+Platform can be pre-selected in `hybrid.config.ts`:
+```typescript
+export const config = {
+  deploy: {
+    platform: "sprites",  // default provider
+    spriteName: "my-agent", // optional instance name override
+  },
+}
+```
+
+Flags: `--provider <name>`, `--name <instance>`, `--force` (recreate), `--no-build` (skip build step).
+
+---
+
+## Provider Implementations
+
+### 1. sprites (`sprite.provider.ts`)
+
+**Current state:** Already implemented inline in `cli.ts` (PR #150). Needs extraction.
+
+**Key commands:**
+| Operation   | Command                                           |
+|-------------|---------------------------------------------------|
+| auth check  | `sprite list` (fails if not installed/authed)     |
+| provision   | `sprite create -skip-console <name>`              |
+| deploy      | `sprite exec -s <name> -file <tar>:/tmp/...` → extract |
+| status      | `sprite list` → parse state                       |
+| sleep       | `sprite sleep <name>`                             |
+| wake        | `sprite exec -s <name> -- echo` (proxy wakes VM) |
+| logs        | `sprite logs -s <name> -f`                        |
+| endpoint    | `https://<name>.sprites.dev`                      |
+| teardown    | `sprite delete <name>`                            |
+
+**Sleep/wake model:** Sprite proxy auto-wakes on `sprite exec`. The `sprite sleep` command pauses the VM. Wake is near-instant (< 2s).
+
+**Implementation notes:**
+- Refactor existing `deploy()` code from `cli.ts` into this provider
+- Extract the retry logic, tar upload, and health-check polling into reusable helpers
+- Keep the `deploy()` shell script generation — useful for CI/CD
+
+### 2. e2b (`e2b.provider.ts`)
+
+**Key SDK calls:**
+| Operation   | SDK Call                                          |
+|-------------|---------------------------------------------------|
+| auth check  | Check `E2B_ACCESS_TOKEN` env var                 |
+| provision   | `Sandbox.create({ sandboxId: templateId })`       |
+| deploy      | `sandbox.commands.run(...)` or `sandbox.files.write(...)` |
+| status      | `sandbox.list()` → find by ID                    |
+| sleep       | `sandbox.pause()`                                 |
+| wake        | `Sandbox.resume(sandboxId)`                       |
+| logs        | `sandbox.commands.run("cat /app/agent.log")`      |
+| endpoint    | `sandbox.getHost(port)`                           |
+| teardown    | `sandbox.kill()`                                  |
+
+**Sleep/wake model:** First-class pause/resume in the SDK. State preserved in memory (sandbox filesystem). Wake is near-instant.
+
+**Implementation notes:**
+- Requires `@e2b/sdk` as an optional peer dependency
+- Create a E2B sandbox template with agent pre-installed for faster cold starts
+- The e2b CLI also works if the SDK isn't preferred
+
+### 3. northflank (`northflank.provider.ts`)
+
+**Key CLI commands:**
+| Operation   | Command                                           |
+|-------------|---------------------------------------------------|
+| auth check  | `nf auth whoami`                                  |
+| provision   | `nf services create` (via API for Firecracker backend) |
+| deploy      | Push Docker image or `nf deploy`                  |
+| status      | `nf services get <serviceId>`                     |
+| sleep       | Scale replicas → 0                                |
+| wake        | Scale replicas → 1 (or inbound request triggers)  |
+| logs        | `nf services logs <serviceId> -f`                 |
+| endpoint    | From service metadata                             |
+| teardown    | `nf services delete <serviceId>`                  |
+
+**Sleep/wake model:** Auto-scale-to-zero handled by the platform. First request after idle triggers a cold start (~5-15s).
+
+**Implementation notes:**
+- Northflank uses Docker images, so `hybrid build` needs to produce an image or the CLI builds it
+- May need to use the NF API directly for Firecracker-backed services (not all CLI features support it)
+- Persistent volumes survive scale-to-zero
+
+### 4. daytona (`daytona.provider.ts`)
+
+**Key CLI commands:**
+| Operation   | Command                                           |
+|-------------|---------------------------------------------------|
+| auth check  | `daytona info`                                    |
+| provision   | `daytona create --image node:20`                  |
+| deploy      | `daytona ssh` + tar upload + extract              |
+| status      | `daytona list` → parse state                      |
+| sleep       | `daytona stop <name>`                             |
+| wake        | `daytona start <name>`                            |
+| logs        | `daytona logs <name>`                             |
+| endpoint    | `daytona ports <name>`                            |
+| teardown    | `daytona delete <name>`                           |
+
+**Sleep/wake model:** Full stop/start. Wake is slow (~30s). Designed for dev environments, not serverless workloads.
+
+**Implementation notes:**
+- Daytona creates dev workspaces, not serverless functions
+- Least aligned with the sleep/wake model — mark as "experimental" initially
+- Still useful for local/dev scenarios where the user wants isolation
+
+---
+
+## Build Changes
+
+### Current state
+- `hybrid build [--target]` defaults to `firecracker`
+- Already generates: `package.json`, `Dockerfile`, `start.sh`
+- Generates a sprites-specific `deploy.sh` (to be removed)
+
+### Changes needed
+
+1. **Remove `deploy.sh`** from `build()` — each provider generates its own deploy artifacts
+2. **Keep Dockerfile generic** for providers that use images (northflank, sprites can use it too)
+3. **Add provider manifest** to build output — a small JSON file with provider-specific config:
+
+```json
+// dist/.hybrid-deploy.json
+{
+  "version": 1,
+  "provider": "firecracker",
+  "startCommand": "node server/index.cjs",
+  "port": 8454,
+  "healthPath": "/health"
+}
+```
+
+---
+
+## Sleep/Wake Trigger Flow
+
+For the "wake on message" model to work, there needs to be a proxy/forwarder that:
+
+1. Receives an incoming message (webhook, API call, chat event)
+2. Calls `provider.wake(instanceId)` if the VM is asleep
+3. Polls `provider.status(instanceId)` until "running"
+4. Forwards the message to the agent endpoint
+5. After idle timeout, calls `provider.sleep(instanceId)`
+
+This is a **separate concern** from `hybrid deploy` — it's the **webhook gateway** service. Documented separately in `specs/webhook-gateway.md`.
+
+What `hybrid deploy` does:
+- Provision the VM with the right config to receive wake signals
+- Set up the agent to handle the health/webhook endpoint
+- Provide sleep/wake CLI commands for manual control
+- Configure idle-timeout for auto-sleep (provider-specific)
+
+---
+
+## Error Handling & UX
+
+### Provider not installed
+```
+❌ 'sprite' CLI not found.
+   Install it: brew install sprites/tap/sprite
+   Or: https://sprites.dev/docs/install
+```
+
+### Provider not authenticated
+```
+❌ Not authenticated with E2B.
+   Run: export E2B_ACCESS_TOKEN=your_token
+   Or: https://e2b.dev/docs/getting-started
+```
+
+### Deploy failure with retry
+```
+📤 Uploading build artifacts...
+   Upload failed, retrying... (1/3)
+   Upload failed, retrying... (2/3)
+   ✅ Uploaded (3 retries)
+```
+
+### Instance name taken
+```
+⚠️  Instance 'my-agent' already exists.
+   Use it? [Y/n]
+   → Re-deploy (overwrite)
+   → Create with new name
+   → Cancel
+```
+
+---
+
+## Testing Strategy
+
+### Unit tests
+- Mock `execFileSync` / `spawn` for CLI-based providers
+- Mock SDK calls for e2b provider
+- Test provider interface contract with a mock provider
+
+### Integration tests
+- Require real `sprite` CLI installed for sprite provider tests
+- Skip if CLI not found (`describe.skipIf(!hasCli(...))`)
+- E2E: `deploy → status → sleep → wake → logs → teardown`
+
+### Manual test matrix
+| Provider  | Deploy | Sleep | Wake | Logs | Status | Teardown |
+|-----------|--------|-------|------|------|--------|----------|
+| sprites   | ✅     | ✅    | ✅   | ✅   | ✅     | ✅       |
+| e2b       |        |       |      |      |        |          |
+| northflank|        |       |      |      |        |          |
+| daytona   |        |       |      |      |        |          |
+
+---
+
+## Implementation Plan
+
+### Phase 4a — Extract sprites provider (current PR #150 cleanup)
+- [ ] Create `DeployProvider` interface in `deploy-provider.ts`
+- [ ] Create `deploy.ts` orchestration
+- [ ] Extract sprites logic from `cli.ts` → `sprite.provider.ts`
+- [ ] Refactor `cli.ts` `deploy()` to use provider interface
+- [ ] Add `deploy:sleep`, `deploy:wake`, `deploy:status`, `deploy:logs` subcommands
+- [ ] Add `deploy:teardown` command
+- [ ] Remove hardcoded `deploy.sh` from `build()`
+- [ ] Update `hybrid.config.ts` schema
+
+### Phase 4b — E2B provider
+- [ ] Implement `e2b.provider.ts`
+- [ ] Add `@e2b/sdk` as optional peer dep
+- [ ] Integration tests with e2b sandbox
+- [ ] Create base E2B template with agent pre-installed
+
+### Phase 4c — Northflank provider
+- [ ] Implement `northflank.provider.ts`
+- [ ] Docker image build path for northflank
+- [ ] Integration tests
+
+### Phase 4d — Daytona provider
+- [ ] Implement `daytona.provider.ts`
+- [ ] Mark as experimental in CLI
+- [ ] Basic integration tests
+
+---
+
+## Related Files
+
+| File                    | Purpose                                      |
+|-------------------------|----------------------------------------------|
+| `packages/cli/src/cli.ts` | Main CLI entry (will delegate to `deploy/`) |
+| `packages/cli/src/deploy/` | Deploy provider system (new)              |
+| `ian/spawn/manifest.json` | Spawn agent registry (sprites)             |
+| `ian/spawn/installers/hybrid.sh` | Spawn installer shim              |
+| `deployments/spawn/Dockerfile` | Firecracker agent image              |
+| `specs/sprites/`        | Sprites two-Sprite architecture spec         |
+| `hybrid.config.ts`      | Project-level config (platform, instance name)|

--- a/specs/cli-deploy-firecracker/SPEC.md
+++ b/specs/cli-deploy-firecracker/SPEC.md
@@ -143,11 +143,11 @@ deploy(platform?)
 
 ```
 hybrid deploy [platform]              Deploy to a Firecracker provider
-hybrid deploy:sleep <name> [--provider sprites|e2b|...]   Put VM to sleep
-hybrid deploy:wake <name>  [--provider sprites|e2b|...]   Wake VM
-hybrid deploy:status <name> [--provider sprites|e2b|...]  Show VM status
-hybrid deploy:logs <name> [--provider sprites|e2b|...]    Stream agent logs
-hybrid deploy:teardown <name> [--all]                     Destroy VM(s)
+hybrid deploy sleep <name> [--provider sprites|e2b|...]   Put VM to sleep
+hybrid deploy wake <name>  [--provider sprites|e2b|...]   Wake VM
+hybrid deploy status <name> [--provider sprites|e2b|...]  Show VM status
+hybrid deploy logs <name> [--provider sprites|e2b|...]    Stream agent logs
+hybrid deploy teardown <name> [--all]                     Destroy VM(s)
 ```
 
 Platform can be pre-selected in `hybrid.config.ts`:
@@ -368,8 +368,8 @@ What `hybrid deploy` does:
 - [ ] Create `deploy.ts` orchestration
 - [ ] Extract sprites logic from `cli.ts` → `sprite.provider.ts`
 - [ ] Refactor `cli.ts` `deploy()` to use provider interface
-- [ ] Add `deploy:sleep`, `deploy:wake`, `deploy:status`, `deploy:logs` subcommands
-- [ ] Add `deploy:teardown` command
+- [ ] Add `deploy sleep`, `deploy wake`, `deploy status`, `deploy logs` subcommands
+- [ ] Add `deploy teardown` command
 - [ ] Remove hardcoded `deploy.sh` from `build()`
 - [ ] Update `hybrid.config.ts` schema
 


### PR DESCRIPTION
## Phase 4: Spawn + Sprites Deployment

### Scope
- Add Hybrid as an agent in Spawn's `manifest.json`
- Create Hybrid installer script for Spawn (`installers/hybrid.sh`)
- Implement Sprites deployment target using Sprite architecture
- Add `hybrid deploy` CLI command targeting Spawn clouds
- Support Sprite-specific config (memory limits, networking, volumes)

### Changes
- **CLI** — switched default build/deploy from Fly.io/Railway to Firecracker (Sprite)
- **CLI deploy()** — rewritten for Spawn Sprite platform with sprite creation, artifact upload, and agent start
- **Build** — generates `deploy.sh` script for Sprite deployment
- **Spawn manifest** — `ian/spawn/manifest.json` with Hybrid agent entry
- **Installer** — `ian/spawn/installers/hybrid.sh` Spawn shim script
- **Dockerfile** — `deployments/spawn/Dockerfile` for Sprite image
- **Config** — `hybrid.config.ts` with `deployPlatform = "firecracker"`

### Related
- Spawn supports 7 clouds: Local, Hetzner, AWS Lightsail, DigitalOcean, GCP, Daytona, Sprite
- Sprites use two-Sprite zero-knowledge architecture (Agent Sprite + Vault Sprite)

Closes HYBRID-140